### PR TITLE
Fix typeError method BaseActiveRecord::FindAll().

### DIFF
--- a/src/ActiveRecordInterface.php
+++ b/src/ActiveRecordInterface.php
@@ -293,10 +293,11 @@ interface ActiveRecordInterface
      * $model = Post::findOne($id);
      * ```
      *
-     * @param mixed $condition primary key value or a set of column values
+     * @param mixed $condition primary key value or a set of column values.
+     *
      * @return array an array of ActiveRecord instance, or an empty array if nothing matches.
      */
-    public static function findAll($condition);
+    public static function findAll($condition): array;
 
     /**
      * Updates records using the provided attribute values and conditions.

--- a/src/BaseActiveRecord.php
+++ b/src/BaseActiveRecord.php
@@ -40,12 +40,22 @@ abstract class BaseActiveRecord implements ActiveRecordInterface, \IteratorAggre
     private array $related = [];
     private array $relationsDependencies = [];
 
+    /**
+     * @param mixed $condition primary key value or a set of column values.
+     *
+     * @return static|null ActiveRecord instance matching the condition, or `null` if nothing matches.
+     */
     public static function findOne($condition): ?ActiveRecordInterface
     {
         return static::findByCondition($condition)->one();
     }
 
-    public static function findAll($condition): ActiveRecordInterface
+    /**
+     * @param mixed $condition primary key value or a set of column values.
+     *
+     * @return array of ActiveRecord instance, or an empty array if nothing matches.
+     */
+    public static function findAll($condition): array
     {
         return static::findByCondition($condition)->all();
     }

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -36,6 +36,8 @@ use Yiisoft\Db\Query\Query;
 use Yiisoft\Db\Exception\InvalidArgumentException;
 use Yiisoft\Db\Exception\StaleObjectException;
 
+use function count;
+
 abstract class ActiveRecordTest extends TestCase
 {
     use ActiveRecordTestTrait;
@@ -67,6 +69,13 @@ abstract class ActiveRecordTest extends TestCase
         $this->assertEquals(1, Customer::find()->min('[[id]]'));
         $this->assertEquals(3, Customer::find()->max('[[id]]'));
         $this->assertEquals(3, Customer::find()->select('COUNT(*)')->scalar());
+    }
+
+    public function testFindAll(): void
+    {
+        $this->assertEquals(1, count(Customer::findAll(3)));
+        $this->assertEquals(1, count(Customer::findAll(['id' => 1])));
+        $this->assertEquals(3, count(Customer::findAll(['id' => [1, 2, 3]])));
     }
 
     public function testFindScalar(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #86 
