### PR TITLE
From yii2 Fix #17174: Fix BaseActiveRecord::unlink()` to not ignore `on` conditions in `via` relations

### DIFF
--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -507,7 +507,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      * @throws NotFoundException
      * @throws NotInstantiableException
      */
-    private function buildJoinWith(): void
+    public function buildJoinWith(): void
     {
         $join = $this->join;
 
@@ -639,7 +639,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                     $callback($relation);
                 }
 
-                if (!empty($relation->joinWith)) {
+                if (!empty($relation->getJoinWith())) {
                     $relation->buildJoinWith();
                 }
 

--- a/src/ActiveQueryInterface.php
+++ b/src/ActiveQueryInterface.php
@@ -74,6 +74,12 @@ interface ActiveQueryInterface extends QueryInterface
      */
     public function via(string $relationName, callable $callable = null): self;
 
+    public function getOn(): array|string|null;
+
+    public function getJoinWith(): array;
+
+    public function buildJoinWith(): void;
+
     /**
      * Finds the related records for the specified primary record.
      *

--- a/src/BaseActiveRecord.php
+++ b/src/BaseActiveRecord.php
@@ -863,6 +863,10 @@ abstract class BaseActiveRecord implements ActiveRecordInterface, IteratorAggreg
                 $nulls[$a] = null;
             }
 
+            if ($viaRelation->getOn() !== null) {
+                $columns = ['and', $columns, $viaRelation->getOn()];
+            }
+
             if (is_array($relation->getVia())) {
                 if ($delete) {
                     $viaClass->deleteAll($columns);

--- a/tests/ActiveQueryTest.php
+++ b/tests/ActiveQueryTest.php
@@ -2325,10 +2325,17 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertCount(2, $order->orderItems);
 
         /** via model without delete */
-        $this->assertCount(3, $order->itemsWithNullFK);
-        $order->unlink('itemsWithNullFK', $order->itemsWithNullFK[2], false);
+//        $this->assertCount(3, $order->itemsWithNullFK);
+//        $order->unlink('itemsWithNullFK', $order->itemsWithNullFK[2], false);
+//        $this->assertCount(2, $order->itemsWithNullFK);
+//        $this->assertCount(2, $order->orderItems);
+
         $this->assertCount(2, $order->itemsWithNullFK);
+        $order->unlink('itemsWithNullFK', $order->itemsWithNullFK[1], false);
+
+        $this->assertCount(1, $order->itemsWithNullFK);
         $this->assertCount(2, $order->orderItems);
+
     }
 
     public function testUnlinkAllAndConditionSetNull(): void

--- a/tests/ActiveQueryTest.php
+++ b/tests/ActiveQueryTest.php
@@ -2325,17 +2325,11 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertCount(2, $order->orderItems);
 
         /** via model without delete */
-//        $this->assertCount(3, $order->itemsWithNullFK);
-//        $order->unlink('itemsWithNullFK', $order->itemsWithNullFK[2], false);
-//        $this->assertCount(2, $order->itemsWithNullFK);
-//        $this->assertCount(2, $order->orderItems);
-
         $this->assertCount(2, $order->itemsWithNullFK);
         $order->unlink('itemsWithNullFK', $order->itemsWithNullFK[1], false);
 
         $this->assertCount(1, $order->itemsWithNullFK);
         $this->assertCount(2, $order->orderItems);
-
     }
 
     public function testUnlinkAllAndConditionSetNull(): void

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -654,8 +654,6 @@ abstract class ActiveRecordTest extends TestCase
         $this->assertFalse($customerA->equals($customerB));
     }
 
-
-
     public function providerForUnlinkDelete()
     {
         return [
@@ -666,6 +664,7 @@ abstract class ActiveRecordTest extends TestCase
 
     /**
      * @dataProvider providerForUnlinkDelete
+     *
      * @see https://github.com/yiisoft/yii2/issues/17174
      */
     public function testUnlinkWithViaOnCondition($delete, $count)

--- a/tests/Data/mssql.sql
+++ b/tests/Data/mssql.sql
@@ -246,7 +246,7 @@ INSERT INTO [dbo].[order_item_with_null_fk] ([order_id], [item_id], [quantity], 
 INSERT INTO [dbo].[order_item_with_null_fk] ([order_id], [item_id], [quantity], [subtotal]) VALUES (1, 2, 2, 40.0);
 INSERT INTO [dbo].[order_item_with_null_fk] ([order_id], [item_id], [quantity], [subtotal]) VALUES (2, 4, 1, 10.0);
 INSERT INTO [dbo].[order_item_with_null_fk] ([order_id], [item_id], [quantity], [subtotal]) VALUES (2, 5, 1, 15.0);
-INSERT INTO [dbo].[order_item_with_null_fk] ([order_id], [item_id], [quantity], [subtotal]) VALUES (2, 3, 1, 8.0);
+INSERT INTO [dbo].[order_item_with_null_fk] ([order_id], [item_id], [quantity], [subtotal]) VALUES (2, 5, 1, 8.0);
 INSERT INTO [dbo].[order_item_with_null_fk] ([order_id], [item_id], [quantity], [subtotal]) VALUES (3, 2, 1, 40.0);
 
 INSERT INTO [dbo].[document] ([title], [content], [version]) VALUES ('Yii 2.0 guide', 'This is Yii 2.0 guide', 0);

--- a/tests/Data/mysql.sql
+++ b/tests/Data/mysql.sql
@@ -264,7 +264,7 @@ INSERT INTO `order_item_with_null_fk` (order_id, item_id, quantity, subtotal) VA
 INSERT INTO `order_item_with_null_fk` (order_id, item_id, quantity, subtotal) VALUES (1, 2, 2, 40.0);
 INSERT INTO `order_item_with_null_fk` (order_id, item_id, quantity, subtotal) VALUES (2, 4, 1, 10.0);
 INSERT INTO `order_item_with_null_fk` (order_id, item_id, quantity, subtotal) VALUES (2, 5, 1, 15.0);
-INSERT INTO `order_item_with_null_fk` (order_id, item_id, quantity, subtotal) VALUES (2, 3, 1, 8.0);
+INSERT INTO `order_item_with_null_fk` (order_id, item_id, quantity, subtotal) VALUES (2, 5, 1, 8.0);
 INSERT INTO `order_item_with_null_fk` (order_id, item_id, quantity, subtotal) VALUES (3, 2, 1, 40.0);
 
 INSERT INTO `document` (title, content, version) VALUES ('Yii 2.0 guide', 'This is Yii 2.0 guide', 0);

--- a/tests/Data/oci.sql
+++ b/tests/Data/oci.sql
@@ -413,7 +413,7 @@ INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subto
 INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (1, 2, 2, 40.0);
 INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (2, 4, 1, 10.0);
 INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (2, 5, 1, 15.0);
-INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (2, 3, 1, 8.0);
+INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (2, 5, 1, 8.0);
 INSERT INTO "order_item_with_null_fk" ("order_id", "item_id", "quantity", "subtotal") VALUES (3, 2, 1, 40.0);
 
 INSERT INTO "document" ("title", "content", "version") VALUES ('Yii 2.0 guide', 'This is Yii 2.0 guide', 0);

--- a/tests/Data/pgsql.sql
+++ b/tests/Data/pgsql.sql
@@ -268,7 +268,7 @@ INSERT INTO "order_item_with_null_fk" (order_id, item_id, quantity, subtotal) VA
 INSERT INTO "order_item_with_null_fk" (order_id, item_id, quantity, subtotal) VALUES (1, 2, 2, 40.0);
 INSERT INTO "order_item_with_null_fk" (order_id, item_id, quantity, subtotal) VALUES (2, 4, 1, 10.0);
 INSERT INTO "order_item_with_null_fk" (order_id, item_id, quantity, subtotal) VALUES (2, 5, 1, 15.0);
-INSERT INTO "order_item_with_null_fk" (order_id, item_id, quantity, subtotal) VALUES (2, 3, 1, 8.0);
+INSERT INTO "order_item_with_null_fk" (order_id, item_id, quantity, subtotal) VALUES (2, 5, 1, 8.0);
 INSERT INTO "order_item_with_null_fk" (order_id, item_id, quantity, subtotal) VALUES (3, 2, 1, 40.0);
 
 INSERT INTO "document" (title, content, version) VALUES ('Yii 2.0 guide', 'This is Yii 2.0 guide', 0);

--- a/tests/Data/sqlite.sql
+++ b/tests/Data/sqlite.sql
@@ -228,7 +228,7 @@ INSERT INTO "order_item_with_null_fk" (order_id, item_id, quantity, subtotal) VA
 INSERT INTO "order_item_with_null_fk" (order_id, item_id, quantity, subtotal) VALUES (1, 2, 2, 40.0);
 INSERT INTO "order_item_with_null_fk" (order_id, item_id, quantity, subtotal) VALUES (2, 4, 1, 10.0);
 INSERT INTO "order_item_with_null_fk" (order_id, item_id, quantity, subtotal) VALUES (2, 5, 1, 15.0);
-INSERT INTO "order_item_with_null_fk" (order_id, item_id, quantity, subtotal) VALUES (2, 3, 1, 8.0);
+INSERT INTO "order_item_with_null_fk" (order_id, item_id, quantity, subtotal) VALUES (2, 5, 1, 8.0);
 INSERT INTO "order_item_with_null_fk" (order_id, item_id, quantity, subtotal) VALUES (3, 2, 1, 40.0);
 
 INSERT INTO "document" (title, content, version) VALUES ('Yii 2.0 guide', 'This is Yii 2.0 guide', 0);

--- a/tests/Oracle/ActiveQueryFindTest.php
+++ b/tests/Oracle/ActiveQueryFindTest.php
@@ -36,7 +36,7 @@ final class ActiveQueryFindTest extends AbstractActiveQueryFindTest
 
     public function testFindEager(): void
     {
-        $this->checkFixture($this->db, 'customer');
+        $this->checkFixture($this->db, 'customer', true);
 
         $customerQuery = new ActiveQuery(Customer::class, $this->db);
         $customers = $customerQuery->with('orders')->indexBy('id')->all();

--- a/tests/Stubs/ActiveRecord/Order.php
+++ b/tests/Stubs/ActiveRecord/Order.php
@@ -198,4 +198,14 @@ class Order extends ActiveRecord
             0 => 'customer_id',
         ];
     }
+
+    public function getOrderItemsFor8()
+    {
+        return $this->hasMany(OrderItemWithNullFK::class, ['order_id' => 'id'])->andOnCondition(['subtotal' => 8.0]);
+    }
+
+    public function getItemsFor8()
+    {
+        return $this->hasMany(Item::class, ['id' => 'item_id'])->via('orderItemsFor8');
+    }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

