### PR TITLE
Do not catch an `Exception` in `isset()` of magic properties

### DIFF
--- a/src/BaseActiveRecordTrait.php
+++ b/src/BaseActiveRecordTrait.php
@@ -156,7 +156,7 @@ trait BaseActiveRecordTrait
     {
         try {
             return $this->__get($name) !== null;
-        } catch (Throwable) {
+        } catch (InvalidCallException|UnknownPropertyException) {
             return false;
         }
     }

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests;
 
+use DivisionByZeroError;
 use ReflectionException;
 use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Animal;
@@ -390,7 +391,8 @@ abstract class ActiveRecordTest extends TestCase
 
         $cat = new Cat($this->db);
 
-        $this->assertFalse(isset($cat->exception));
+        $this->expectException(Exception::class);
+        isset($cat->exception);
     }
 
     public function testIssetThrowable(): void
@@ -399,7 +401,18 @@ abstract class ActiveRecordTest extends TestCase
 
         $cat = new Cat($this->db);
 
-        $this->assertFalse(isset($cat->throwable));
+        $this->expectException(DivisionByZeroError::class);
+        isset($cat->throwable);
+    }
+
+    public function testIssetNonExisting(): void
+    {
+        $this->checkFixture($this->db, 'cat');
+
+        $cat = new Cat($this->db);
+
+        $this->assertFalse(isset($cat->non_existing));
+        $this->assertFalse(isset($cat->non_existing_property));
     }
 
     public function testSetAttributes(): void

--- a/tests/Stubs/ActiveRecord/Cat.php
+++ b/tests/Stubs/ActiveRecord/Cat.php
@@ -29,4 +29,8 @@ final class Cat extends Animal
     {
         return 5/0;
     }
+
+    public function setNonExistingProperty(string $value): void
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #9
