### PR TITLE
Refactor `update...()` methods

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -14,4 +14,7 @@
         <directory name="vendor" />
     </ignoreFiles>
   </projectFiles>
+  <issueHandlers>
+    <MixedAssignment errorLevel="suppress" />
+  </issueHandlers>
 </psalm>

--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -366,10 +366,6 @@ class ActiveRecord extends BaseActiveRecord
         $condition = $this->getOldPrimaryKey(true);
         $lock = $this->optimisticLock();
 
-        if (is_array($condition) === false) {
-            return false;
-        }
-
         if ($lock !== null) {
             $condition[$lock] = $this->$lock;
         }

--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -323,7 +323,7 @@ class ActiveRecord extends BaseActiveRecord
         return [];
     }
 
-    public function update(array $attributeNames = null): false|int
+    public function update(array $attributeNames = null): int
     {
         if (!$this->isTransactional(self::OP_UPDATE)) {
             return $this->updateInternal($attributeNames);

--- a/src/ActiveRecordInterface.php
+++ b/src/ActiveRecordInterface.php
@@ -159,6 +159,12 @@ interface ActiveRecordInterface
      * @return mixed The old primary key value. An array (column name => column value) is returned if the primary key
      * is composite or `$asArray` is true. A string is returned otherwise (`null` will be returned if the key value is
      * `null`).
+     *
+     * @psalm-return (
+     *     $asArray is true
+     *     ? array<string, mixed>
+     *     : mixed|null
+     * )
      */
     public function getOldPrimaryKey(bool $asArray = false): mixed;
 
@@ -172,6 +178,12 @@ interface ActiveRecordInterface
      * @return mixed The primary key value. An array (attribute name => attribute value) is returned if the primary key
      * is composite or `$asArray` is true. A string is returned otherwise (`null` will be returned if the key value is
      * `null`).
+     *
+     * @psalm-return (
+     *     $asArray is true
+     *     ? array<string, mixed>
+     *     : mixed|null
+     * )
      */
     public function getPrimaryKey(bool $asArray = false): mixed;
 
@@ -322,7 +334,7 @@ interface ActiveRecordInterface
      * @throws Exception
      * @throws InvalidConfigException
      *
-     * @psalm-return string[] The primary keys of the associated database table.
+     * @return string[] The primary keys of the associated database table.
      */
     public function primaryKey(): array;
 
@@ -377,7 +389,7 @@ interface ActiveRecordInterface
      * For this reason, you should use the following code to check if update() is successful or not:
      *
      * ```php
-     * if ($customer->update() !== false) {
+     * if ($customer->update() !== 0) {
      *     // update successful
      * } else {
      *     // update failed
@@ -391,10 +403,9 @@ interface ActiveRecordInterface
      * outdated.
      * @throws Throwable In case update failed.
      *
-     * @return false|int The number of rows affected, or false if validation fails or {@seebeforeSave()} stops the
-     * updating process.
+     * @return int The number of rows affected.
      */
-    public function update(array $attributeNames = null): false|int;
+    public function update(array $attributeNames = null): int;
 
     /**
      * Updates the whole table using the provided attribute values and conditions.
@@ -410,10 +421,10 @@ interface ActiveRecordInterface
      *
      * ```php
      * $customerQuery = new ActiveQuery(Customer::class, $db);
-     * $aqClasses = $customerQuery->where('status = 2')->all();
-     * foreach ($aqClasses as $aqClass) {
-     *     $aqClass->status = 1;
-     *     $aqClass->update();
+     * $customers = $customerQuery->where('status = 2')->all();
+     * foreach ($customers as $customer) {
+     *     $customer->status = 1;
+     *     $customer->update();
      * }
      * ```
      *

--- a/src/BaseActiveRecord.php
+++ b/src/BaseActiveRecord.php
@@ -258,13 +258,13 @@ abstract class BaseActiveRecord implements ActiveRecordInterface, IteratorAggreg
         $keys = $this->primaryKey();
 
         if ($asArray === false && count($keys) === 1) {
-            return $this->attributes[$keys[0]] ?? null;
+            return $this->{$keys[0]};
         }
 
         $values = [];
 
         foreach ($keys as $name) {
-            $values[$name] = $this->attributes[$name] ?? null;
+            $values[$name] = $this->$name;
         }
 
         return $values;
@@ -749,7 +749,7 @@ abstract class BaseActiveRecord implements ActiveRecordInterface, IteratorAggreg
             if (is_int($name)) {
                 $attrs[] = $value;
             } else {
-                $this->setAttribute($name, $value);
+                $this->$name = $value;
                 $attrs[] = $name;
             }
         }
@@ -843,8 +843,9 @@ abstract class BaseActiveRecord implements ActiveRecordInterface, IteratorAggreg
         }
 
         foreach ($counters as $name => $value) {
-            $this->attributes[$name] = ($this->attributes[$name] ?? 0) + $value;
-            $this->oldAttributes[$name] = $this->attributes[$name];
+            $value += $this->$name ?? 0;
+            $this->$name = $value;
+            $this->oldAttributes[$name] = $value;
         }
 
         return true;
@@ -1161,7 +1162,7 @@ abstract class BaseActiveRecord implements ActiveRecordInterface, IteratorAggreg
         $lock = $this->optimisticLock();
 
         if ($lock !== null) {
-            $lockValue = $this->getAttribute($lock);
+            $lockValue = $this->$lock;
 
             $condition[$lock] = $lockValue;
             $values[$lock] = ++$lockValue;
@@ -1172,7 +1173,7 @@ abstract class BaseActiveRecord implements ActiveRecordInterface, IteratorAggreg
                 throw new StaleObjectException('The object being updated is outdated.');
             }
 
-            $this->setAttribute($lock, $lockValue);
+            $this->$lock = $lockValue;
         } else {
             $rows = $this->updateAll($values, $condition);
         }

--- a/src/BaseActiveRecord.php
+++ b/src/BaseActiveRecord.php
@@ -843,7 +843,7 @@ abstract class BaseActiveRecord implements ActiveRecordInterface, IteratorAggreg
         }
 
         foreach ($counters as $name => $value) {
-            $this->attributes[$name] = (int)($this->attributes[$name] ?? 0) + $value;
+            $this->attributes[$name] = ($this->attributes[$name] ?? 0) + $value;
             $this->oldAttributes[$name] = $this->attributes[$name];
         }
 
@@ -1161,7 +1161,7 @@ abstract class BaseActiveRecord implements ActiveRecordInterface, IteratorAggreg
         $lock = $this->optimisticLock();
 
         if ($lock !== null) {
-            $lockValue = (int)$this->getAttribute($lock);
+            $lockValue = $this->getAttribute($lock);
 
             $condition[$lock] = $lockValue;
             $values[$lock] = ++$lockValue;

--- a/src/BaseActiveRecord.php
+++ b/src/BaseActiveRecord.php
@@ -68,10 +68,6 @@ abstract class BaseActiveRecord implements ActiveRecordInterface, IteratorAggreg
           */
         $condition = $this->getOldPrimaryKey(true);
 
-        if (is_array($condition) === false) {
-            return false;
-        }
-
         $lock = $this->optimisticLock();
 
         if ($lock !== null) {
@@ -261,7 +257,7 @@ abstract class BaseActiveRecord implements ActiveRecordInterface, IteratorAggreg
     {
         $keys = $this->primaryKey();
 
-        if (!$asArray && count($keys) === 1) {
+        if ($asArray === false && count($keys) === 1) {
             return $this->attributes[$keys[0]] ?? null;
         }
 

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -836,4 +836,15 @@ abstract class ActiveRecordTest extends TestCase
             ]),
         );
     }
+
+    public function testSaveWithoutChanges()
+    {
+        $this->checkFixture($this->db, 'customer');
+
+        $customerQuery = new ActiveQuery(Customer::class, $this->db);
+
+        $customer = $customerQuery->findOne(1);
+
+        $this->assertTrue($customer->save());
+    }
 }

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -847,4 +847,16 @@ abstract class ActiveRecordTest extends TestCase
 
         $this->assertTrue($customer->save());
     }
+
+    public function testGetPrimaryKey()
+    {
+        $this->checkFixture($this->db, 'customer');
+
+        $customerQuery = new ActiveQuery(Customer::class, $this->db);
+
+        $customer = $customerQuery->findOne(1);
+
+        $this->assertSame(1, $customer->getPrimaryKey());
+        $this->assertSame(['id' => 1], $customer->getPrimaryKey(true));
+    }
 }

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -859,4 +859,16 @@ abstract class ActiveRecordTest extends TestCase
         $this->assertSame(1, $customer->getPrimaryKey());
         $this->assertSame(['id' => 1], $customer->getPrimaryKey(true));
     }
+
+    public function testGetOldPrimaryKey()
+    {
+        $this->checkFixture($this->db, 'customer');
+
+        $customerQuery = new ActiveQuery(Customer::class, $this->db);
+
+        $customer = $customerQuery->findOne(1);
+
+        $this->assertSame(1, $customer->getOldPrimaryKey());
+        $this->assertSame(['id' => 1], $customer->getOldPrimaryKey(true));
+    }
 }

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -867,6 +867,7 @@ abstract class ActiveRecordTest extends TestCase
         $customerQuery = new ActiveQuery(Customer::class, $this->db);
 
         $customer = $customerQuery->findOne(1);
+        $customer->id = 2;
 
         $this->assertSame(1, $customer->getOldPrimaryKey());
         $this->assertSame(['id' => 1], $customer->getOldPrimaryKey(true));

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -837,7 +837,7 @@ abstract class ActiveRecordTest extends TestCase
         );
     }
 
-    public function testSaveWithoutChanges()
+    public function testSaveWithoutChanges(): void
     {
         $this->checkFixture($this->db, 'customer');
 
@@ -848,7 +848,7 @@ abstract class ActiveRecordTest extends TestCase
         $this->assertTrue($customer->save());
     }
 
-    public function testGetPrimaryKey()
+    public function testGetPrimaryKey(): void
     {
         $this->checkFixture($this->db, 'customer');
 
@@ -860,7 +860,7 @@ abstract class ActiveRecordTest extends TestCase
         $this->assertSame(['id' => 1], $customer->getPrimaryKey(true));
     }
 
-    public function testGetOldPrimaryKey()
+    public function testGetOldPrimaryKey(): void
     {
         $this->checkFixture($this->db, 'customer');
 

--- a/tests/Stubs/ActiveRecord/Cat.php
+++ b/tests/Stubs/ActiveRecord/Cat.php
@@ -27,7 +27,7 @@ final class Cat extends Animal
      */
     public function getThrowable(): float|int
     {
-        return 5/0;
+        return 5 / 0;
     }
 
     public function setNonExistingProperty(string $value): void


### PR DESCRIPTION
* Fix bug: `ActiveRecord::save()` without changes should return `true`;
* Fix bug with return type of `ActiveRecord::getOldPrimaryKey()` method;
* Remove redundant `false` return type in `ActiveRecordInterface::update()` method;
* Refactor `BaseActiveRecord::updateAttributes()`;
* Refactor `BaseActiveRecord::updateInternal()`;
* Refactor `BaseActiveRecord::updateCounters()`.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
