### PR TITLE
Refactor `BaseActiveRecord::getDirtyAttributes()`

### DIFF
--- a/src/BaseActiveRecord.php
+++ b/src/BaseActiveRecord.php
@@ -140,21 +140,14 @@ abstract class BaseActiveRecord implements ActiveRecordInterface, IteratorAggreg
 
     public function getAttributes(array $names = null, array $except = []): array
     {
-        $values = [];
-
-        if ($names === null) {
-            $names = $this->attributes();
-        }
+        $names ??= $this->attributes();
+        $attributes = array_merge($this->attributes, get_object_vars($this));
 
         if ($except !== []) {
             $names = array_diff($names, $except);
         }
 
-        foreach ($names as $name) {
-            $values[$name] = $this->$name;
-        }
-
-        return $values;
+        return array_intersect_key($attributes, array_flip($names));
     }
 
     public function getIsNewRecord(): bool
@@ -190,8 +183,7 @@ abstract class BaseActiveRecord implements ActiveRecordInterface, IteratorAggreg
      */
     public function getDirtyAttributes(array $names = null): array
     {
-        $attributes = array_merge($this->attributes, get_object_vars($this));
-        $attributes = array_intersect_key($attributes, array_flip($names ?? $this->attributes()));
+        $attributes = $this->getAttributes($names);
 
         if ($this->oldAttributes === null) {
             return $attributes;

--- a/src/BaseActiveRecord.php
+++ b/src/BaseActiveRecord.php
@@ -22,8 +22,10 @@ use Yiisoft\Db\Expression\Expression;
 use Yiisoft\Db\Helper\DbStringHelper;
 
 use function array_combine;
+use function array_diff_key;
 use function array_flip;
 use function array_intersect;
+use function array_intersect_key;
 use function array_key_exists;
 use function array_keys;
 use function array_search;
@@ -188,40 +190,24 @@ abstract class BaseActiveRecord implements ActiveRecordInterface, IteratorAggreg
     public function getDirtyAttributes(array $names = null): array
     {
         if ($names === null) {
-            $names = $this->attributes();
+            $attributes = $this->attributes;
+        } else {
+            $attributes = array_intersect_key($this->attributes, array_flip($names));
         }
-
-        $names = array_flip($names);
-        $attributes = [];
 
         if ($this->oldAttributes === null) {
-            /**
-             * @var string $name
-             * @var mixed $value
-             */
-            foreach ($this->attributes as $name => $value) {
-                if (isset($names[$name])) {
-                    /** @psalm-var mixed */
-                    $attributes[$name] = $value;
-                }
-            }
-        } else {
-            /**
-             * @var string $name
-             * @var mixed $value
-             */
-            foreach ($this->attributes as $name => $value) {
-                if (
-                    isset($names[$name])
-                    && (!array_key_exists($name, $this->oldAttributes) || $value !== $this->oldAttributes[$name])
-                ) {
-                    /** @psalm-var mixed */
-                    $attributes[$name] = $value;
-                }
+            return $attributes;
+        }
+
+        $result = array_diff_key($attributes, $this->oldAttributes);
+
+        foreach (array_diff_key($attributes, $result) as $name => $value) {
+            if ($value !== $this->oldAttributes[$name]) {
+                $result[$name] = $value;
             }
         }
 
-        return $attributes;
+        return $result;
     }
 
     public function getOldAttributes(): array

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -836,4 +836,56 @@ abstract class ActiveRecordTest extends TestCase
             ]),
         );
     }
+
+    public function testGetDirtyAttributesOnNewRecord(): void
+    {
+        $this->checkFixture($this->db, 'customer');
+
+        $customer = new Customer($this->db);
+
+        $this->assertSame([], $customer->getDirtyAttributes());
+
+        $customer->setAttribute('name', 'Adam');
+        $customer->setAttribute('email', 'adam@example.com');
+        $customer->setAttribute('address', null);
+
+        $this->assertEquals(
+            ['name' => 'Adam', 'email' => 'adam@example.com', 'address' => null],
+            $customer->getDirtyAttributes()
+        );
+        $this->assertEquals(
+            ['email' => 'adam@example.com', 'address' => null],
+            $customer->getDirtyAttributes(['id', 'email', 'address', 'status']),
+        );
+
+        $this->assertTrue($customer->save());
+        $this->assertSame([], $customer->getDirtyAttributes());
+
+        $customer->setAttribute('address', '');
+
+        $this->assertSame(['address' => ''], $customer->getDirtyAttributes());
+    }
+
+    public function testGetDirtyAttributesAfterFind(): void
+    {
+        $this->checkFixture($this->db, 'customer');
+
+        $customerQuery = new ActiveQuery(Customer::class, $this->db);
+        $customer = $customerQuery->findOne(1);
+
+        $this->assertSame([], $customer->getDirtyAttributes());
+
+        $customer->setAttribute('name', 'Adam');
+        $customer->setAttribute('email', 'adam@example.com');
+        $customer->setAttribute('address', null);
+
+        $this->assertEquals(
+            ['name' => 'Adam', 'email' => 'adam@example.com', 'address' => null],
+            $customer->getDirtyAttributes(),
+        );
+        $this->assertEquals(
+            ['email' => 'adam@example.com', 'address' => null],
+            $customer->getDirtyAttributes(['id', 'email', 'address', 'status']),
+        );
+    }
 }

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -13,6 +13,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Customer;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\CustomerClosureField;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\CustomerForArrayable;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\CustomerWithAlias;
+use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\CustomerWithProperties;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Dog;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Item;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\NoExist;
@@ -597,14 +598,9 @@ abstract class ActiveRecordTest extends TestCase
         $this->assertTrue($customer->canGetProperty('orderItems'));
         $this->assertFalse($customer->canSetProperty('orderItems'));
 
-        try {
-            /** @var $itemClass ActiveRecordInterface */
-            $customer->orderItems = [new Item($this->db)];
-            $this->fail('setter call above MUST throw Exception');
-        } catch (Exception $e) {
-            /** catch exception "Setting read-only property" */
-            $this->assertInstanceOf(InvalidCallException::class, $e);
-        }
+        $this->expectException(UnknownPropertyException::class);
+        $this->expectExceptionMessage('Setting unknown property: ' . Customer::class . '::orderItems');
+        $customer->orderItems = [new Item($this->db)];
 
         /** related attribute $customer->orderItems didn't change cause it's read-only */
         $this->assertSame([], $customer->orderItems);
@@ -855,7 +851,7 @@ abstract class ActiveRecordTest extends TestCase
         );
         $this->assertEquals(
             ['email' => 'adam@example.com', 'address' => null],
-            $customer->getDirtyAttributes(['id', 'email', 'address', 'status']),
+            $customer->getDirtyAttributes(['id', 'email', 'address', 'status', 'unknown']),
         );
 
         $this->assertTrue($customer->save());
@@ -885,7 +881,37 @@ abstract class ActiveRecordTest extends TestCase
         );
         $this->assertEquals(
             ['email' => 'adam@example.com', 'address' => null],
-            $customer->getDirtyAttributes(['id', 'email', 'address', 'status']),
+            $customer->getDirtyAttributes(['id', 'email', 'address', 'status', 'unknown']),
+        );
+    }
+
+    public function testGetDirtyAttributesWithProperties(): void
+    {
+        $this->checkFixture($this->db, 'customer');
+
+        $customer = new CustomerWithProperties($this->db);
+        $this->assertSame([
+            'name' => null,
+            'address' => null,
+        ], $customer->getDirtyAttributes());
+
+        $customerQuery = new ActiveQuery(CustomerWithProperties::class, $this->db);
+        $customer = $customerQuery->findOne(1);
+
+        $this->assertSame([], $customer->getDirtyAttributes());
+
+        $customer->setEmail('adam@example.com');
+        $customer->setName('Adam');
+        $customer->setAddress(null);
+        $customer->setStatus(null);
+
+        $this->assertEquals(
+            ['email' => 'adam@example.com', 'name' => 'Adam', 'address' => null, 'status' => null],
+            $customer->getDirtyAttributes(),
+        );
+        $this->assertEquals(
+            ['email' => 'adam@example.com', 'address' => null],
+            $customer->getDirtyAttributes(['id', 'email', 'address', 'unknown']),
         );
     }
 }

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -25,6 +25,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Type;
 use Yiisoft\ActiveRecord\Tests\Support\Assert;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidArgumentException;
+use Yiisoft\Db\Exception\InvalidCallException;
 use Yiisoft\Db\Exception\InvalidConfigException;
 use Yiisoft\Db\Exception\UnknownPropertyException;
 use Yiisoft\Db\Query\Query;
@@ -597,8 +598,8 @@ abstract class ActiveRecordTest extends TestCase
         $this->assertTrue($customer->canGetProperty('orderItems'));
         $this->assertFalse($customer->canSetProperty('orderItems'));
 
-        $this->expectException(UnknownPropertyException::class);
-        $this->expectExceptionMessage('Setting unknown property: ' . Customer::class . '::orderItems');
+        $this->expectException(InvalidCallException::class);
+        $this->expectExceptionMessage('Setting read-only property: ' . Customer::class . '::orderItems');
         $customer->orderItems = [new Item($this->db)];
 
         /** related attribute $customer->orderItems didn't change cause it's read-only */

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -25,7 +25,6 @@ use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Type;
 use Yiisoft\ActiveRecord\Tests\Support\Assert;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidArgumentException;
-use Yiisoft\Db\Exception\InvalidCallException;
 use Yiisoft\Db\Exception\InvalidConfigException;
 use Yiisoft\Db\Exception\UnknownPropertyException;
 use Yiisoft\Db\Query\Query;

--- a/tests/Stubs/ActiveRecord/CustomerWithProperties.php
+++ b/tests/Stubs/ActiveRecord/CustomerWithProperties.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord;
+
+use Yiisoft\ActiveRecord\ActiveQuery;
+use Yiisoft\ActiveRecord\ActiveRecord;
+
+/**
+ * Class Customer with defined properties.
+ */
+class CustomerWithProperties extends ActiveRecord
+{
+    protected int $id;
+    protected string $email;
+    protected string|null $name = null;
+    public string|null $address = null;
+
+    public function getTableName(): string
+    {
+        return 'customer';
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getName(): string|null
+    {
+        return $this->name;
+    }
+
+    public function getAddress(): string|null
+    {
+        return $this->address;
+    }
+
+    public function getStatus(): int|null
+    {
+        return $this->getAttribute('status');
+    }
+
+    public function getProfile(): ActiveQuery
+    {
+        return $this->hasOne(Profile::class, ['id' => 'profile_id']);
+    }
+
+    public function getOrders(): ActiveQuery
+    {
+        return $this->hasMany(Order::class, ['customer_id' => 'id'])->orderBy('[[id]]');
+    }
+
+    public function setEmail(string $email): void
+    {
+        $this->email = $email;
+    }
+
+    public function setName(string|null $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function setAddress(string|null $address): void
+    {
+        $this->address = $address;
+    }
+
+    public function setStatus(int|null $status): void
+    {
+        $this->setAttribute('status', $status);
+    }
+}


### PR DESCRIPTION
* Improve performance
* Allow to use class properties (mixed with `$attributes` if no class properties) for table row values.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -