### PR TITLE
Refactor `delete...()` methods

### DIFF
--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -8,7 +8,6 @@ use Throwable;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidArgumentException;
 use Yiisoft\Db\Exception\InvalidConfigException;
-use Yiisoft\Db\Exception\StaleObjectException;
 use Yiisoft\Db\Schema\TableSchemaInterface;
 
 use function array_diff;

--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -114,7 +114,7 @@ class ActiveRecord extends BaseActiveRecord
         return $this->getTableSchema()->getColumnNames();
     }
 
-    public function delete(): false|int
+    public function delete(): int
     {
         if (!$this->isTransactional(self::OP_DELETE)) {
             return $this->deleteInternal();
@@ -124,11 +124,7 @@ class ActiveRecord extends BaseActiveRecord
 
         try {
             $result = $this->deleteInternal();
-            if ($result === false) {
-                $transaction->rollBack();
-            } else {
-                $transaction->commit();
-            }
+            $transaction->commit();
 
             return $result;
         } catch (Throwable $e) {
@@ -344,45 +340,6 @@ class ActiveRecord extends BaseActiveRecord
             $transaction->rollBack();
             throw $e;
         }
-    }
-
-    /**
-     * Deletes an ActiveRecord without considering transaction.
-     *
-     * Note that it is possible the number of rows deleted is 0, even though the deletion execution is successful.
-     *
-     * @throws Exception
-     * @throws StaleObjectException
-     * @throws Throwable
-     *
-     * @return false|int The number of rows deleted, or `false` if the deletion is unsuccessful for some reason.
-     */
-    protected function deleteInternal(): false|int
-    {
-        /**
-         * We do not check the return value of deleteAll() because it's possible the record is already deleted in the
-         * database and thus the method will return 0.
-         */
-        $condition = $this->getOldPrimaryKey(true);
-        $lock = $this->optimisticLock();
-
-        if (is_array($condition) === false) {
-            return false;
-        }
-
-        if ($lock !== null) {
-            $condition[$lock] = $this->$lock;
-        }
-
-        $result = $this->deleteAll($condition);
-
-        if ($lock !== null && !$result) {
-            throw new StaleObjectException('The object being deleted is outdated.');
-        }
-
-        $this->setOldAttributes();
-
-        return $result;
     }
 
     /**

--- a/src/ActiveRecordInterface.php
+++ b/src/ActiveRecordInterface.php
@@ -34,11 +34,11 @@ interface ActiveRecordInterface
      * is outdated.
      * @throws Throwable In case delete failed.
      *
-     * @return false|int The number of rows deleted, or `false` if the deletion is unsuccessful for some reason.
+     * @return int The number of rows deleted.
      *
      * Note that it's possible the number of rows deleted is 0, even though the deletion execution is successful.
      */
-    public function delete(): false|int;
+    public function delete(): int;
 
     /**
      * Deletes rows in the table using the provided conditions.

--- a/src/BaseActiveRecord.php
+++ b/src/BaseActiveRecord.php
@@ -1121,7 +1121,7 @@ abstract class BaseActiveRecord implements ActiveRecordInterface, IteratorAggreg
         $lock = $this->optimisticLock();
 
         if ($lock !== null) {
-            $condition[$lock] = $this->getAttribute($lock);
+            $condition[$lock] = $this->$lock;
 
             $result = $this->deleteAll($condition);
 

--- a/tests/ActiveQueryTest.php
+++ b/tests/ActiveQueryTest.php
@@ -2007,7 +2007,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testOptimisticLockOnDelete(): void
     {
-        $this->checkFixture($this->db, 'document');
+        $this->checkFixture($this->db, 'document', true);
 
         $documentQuery = new ActiveQuery(Document::class, $this->db);
         $document = $documentQuery->findOne(1);
@@ -2022,7 +2022,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testOptimisticLockAfterDelete(): void
     {
-        $this->checkFixture($this->db, 'document');
+        $this->checkFixture($this->db, 'document', true);
 
         $documentQuery = new ActiveQuery(Document::class, $this->db);
         $document = $documentQuery->findOne(1);

--- a/tests/ActiveQueryTest.php
+++ b/tests/ActiveQueryTest.php
@@ -2005,6 +2005,36 @@ abstract class ActiveQueryTest extends TestCase
         $record->save();
     }
 
+    public function testOptimisticLockOnDelete(): void
+    {
+        $this->checkFixture($this->db, 'document');
+
+        $documentQuery = new ActiveQuery(Document::class, $this->db);
+        $document = $documentQuery->findOne(1);
+
+        $this->assertSame(0, $document->version);
+
+        $document->version = 1;
+
+        $this->expectException(StaleObjectException::class);
+        $document->delete();
+    }
+
+    public function testOptimisticLockAfterDelete(): void
+    {
+        $this->checkFixture($this->db, 'document');
+
+        $documentQuery = new ActiveQuery(Document::class, $this->db);
+        $document = $documentQuery->findOne(1);
+
+        $this->assertSame(0, $document->version);
+        $this->assertSame(1, $document->delete());
+        $this->assertTrue($document->getIsNewRecord());
+
+        $this->expectException(StaleObjectException::class);
+        $document->delete();
+    }
+
     /**
      * {@see https://github.com/yiisoft/yii2/issues/9006}
      */

--- a/tests/Stubs/ActiveRecord/Cat.php
+++ b/tests/Stubs/ActiveRecord/Cat.php
@@ -27,7 +27,7 @@ final class Cat extends Animal
      */
     public function getThrowable(): float|int
     {
-        return 5/0;
+        return 5 / 0;
     }
 
     public function setNonExistingProperty(string $value): void


### PR DESCRIPTION
* Remove redundant `false` return type in `ActiveRecordInterface::delelte()` method
* Refactor and move `ActiveRecord::deleteInternal()` to `BaseActiveRecord::deleteInternal()`
* Add optimistic lock tests on delete and after delete.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
