### PR TITLE
BaseActiveRecordTrait allow attribute setter

### DIFF
--- a/src/BaseActiveRecordTrait.php
+++ b/src/BaseActiveRecordTrait.php
@@ -192,6 +192,12 @@ trait BaseActiveRecordTrait
      */
     public function __set(string $name, mixed $value): void
     {
+        $setter = 'set' . $name;
+        if (method_exists($this, $setter)) {
+            $this->$setter($value);
+            return;
+        }
+
         if ($this->hasAttribute($name)) {
             if (
                 !empty($this->relationsDependencies[$name])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    |  ✔️❌ (maybe)
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

attribute setter not working, when `canSetProperty('passwordRepeat')` said `true` but,
when i do `$model->passwordRepeat =$post['password_repeat']` it is throwing
`Setting unknown property: app\models\User::passwordRepeat`.

the code was using the same technique as Yii2 https://github.com/yiisoft/yii2/blob/97ca1f2b18a301d2e932f8eb4b07410d96a17edb/framework/base/Component.php#L178