### PR TITLE
Remove `$throwException` from `ActiveRecordInterface::relationQuery()`

### DIFF
--- a/src/ActiveRecordInterface.php
+++ b/src/ActiveRecordInterface.php
@@ -326,7 +326,7 @@ interface ActiveRecordInterface
      * Relations can be defined using {@see hasOne()} and {@see hasMany()} methods. For example:
      *
      * ```php
-     * public function relationQuery(string $name, bool $throwException = true): ActiveQueryInterface
+     * public function relationQuery(string $name): ActiveQueryInterface
      * {
      *     return match ($name) {
      *         'orders' => $this->hasMany(Order::class, ['customer_id' => 'id']),
@@ -337,13 +337,12 @@ interface ActiveRecordInterface
      * ```
      *
      * @param string $name The relation name, for example `orders` (case-sensitive).
-     * @param bool $throwException Whether to throw exception if the relation doesn't exist.
      *
      * @throws InvalidArgumentException
      *
-     * @return ActiveQueryInterface|null The relational query object.
+     * @return ActiveQueryInterface The relational query object.
      */
-    public function relationQuery(string $name, bool $throwException = true): ActiveQueryInterface|null;
+    public function relationQuery(string $name): ActiveQueryInterface;
 
     /**
      * Resets relation data for the specified name.

--- a/src/Trait/MagicRelationsTrait.php
+++ b/src/Trait/MagicRelationsTrait.php
@@ -37,25 +37,14 @@ trait MagicRelationsTrait
      * }
      * ```
      *
-     * @param string $name The relation name, for example `orders` for a relation defined via `getOrdersQuery()` method
-     * (case-sensitive).
-     * @param bool $throwException whether to throw exception if the relation does not exist.
-     *
      * @throws InvalidArgumentException if the named relation does not exist.
      * @throws ReflectionException
-     *
-     * @return ActiveQueryInterface|null the relational query object. If the relation does not exist and
-     * `$throwException` is `false`, `null` will be returned.
      */
-    public function relationQuery(string $name, bool $throwException = true): ActiveQueryInterface|null
+    public function relationQuery(string $name): ActiveQueryInterface
     {
         $getter = 'get' . ucfirst($name) . 'Query';
 
         if (!method_exists($this, $getter)) {
-            if (!$throwException) {
-                return null;
-            }
-
             throw new InvalidArgumentException(static::class . ' has no relation named "' . $name . '".');
         }
 
@@ -66,10 +55,6 @@ trait MagicRelationsTrait
             $type === null
             || !is_a('\\' . $type->getName(), ActiveQueryInterface::class, true)
         ) {
-            if (!$throwException) {
-                return null;
-            }
-
             $typeName = $type === null ? 'mixed' : $type->getName();
 
             throw new InvalidArgumentException(
@@ -82,10 +67,6 @@ trait MagicRelationsTrait
         $realName = lcfirst(substr($method->getName(), 3, -5));
 
         if ($realName !== $name) {
-            if (!$throwException) {
-                return null;
-            }
-
             throw new InvalidArgumentException(
                 'Relation names are case sensitive. ' . static::class
                 . " has a relation named \"$realName\" instead of \"$name\"."

--- a/tests/ActiveQueryTest.php
+++ b/tests/ActiveQueryTest.php
@@ -2331,9 +2331,6 @@ abstract class ActiveQueryTest extends TestCase
 
         $query = $customer->findOne(1);
 
-        /** Without throwing exception */
-        $this->assertEmpty($query->relationQuery('items', false));
-
         /** Throwing exception */
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -2350,9 +2347,6 @@ abstract class ActiveQueryTest extends TestCase
 
         $query = $customer->findOne(1);
 
-        /** Without throwing exception */
-        $this->assertEmpty($query->relationQuery('item', false));
-
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             'Relation query method "Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Customer::getItemQuery()" should'
@@ -2368,8 +2362,6 @@ abstract class ActiveQueryTest extends TestCase
         $customer = new ActiveQuery(Customer::class, $this->db);
 
         $query = $customer->findOne(1);
-
-        $this->assertEmpty($query->relationQuery('expensiveorders', false));
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #331 #308 
