### PR TITLE
Refactor - rename `getObjectVars()` to `getAttributesInternal()`

### DIFF
--- a/src/AbstractActiveRecord.php
+++ b/src/AbstractActiveRecord.php
@@ -56,17 +56,11 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
     /**
      * Returns the public and protected property values of an Active Record object.
      *
-     * This method is provided because a direct call of {@see get_object_vars()} within the {@see AbstractActiveRecord}
-     * class will return also private property values of {@see AbstractActiveRecord} class.
-     *
-     * @param ActiveRecordInterface $object
-     *
      * @return array
-     * @link https://www.php.net/manual/en/function.get-object-vars.php
      *
      * @psalm-return array<string, mixed>
      */
-    abstract protected function getObjectVars(ActiveRecordInterface $object): array;
+    abstract protected function getAttributesInternal(): array;
 
     /**
      * Inserts Active Record values into DB without considering transaction.
@@ -112,7 +106,7 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
 
     public function getAttribute(string $name): mixed
     {
-        return $this->getObjectVars($this)[$name] ?? null;
+        return $this->getAttributesInternal()[$name] ?? null;
     }
 
     public function getAttributes(array|null $names = null, array $except = []): array
@@ -123,7 +117,7 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
             $names = array_diff($names, $except);
         }
 
-        return array_intersect_key($this->getObjectVars($this), array_flip($names));
+        return array_intersect_key($this->getAttributesInternal(), array_flip($names));
     }
 
     public function getIsNewRecord(): bool
@@ -345,11 +339,13 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
      */
     public function isAttributeChanged(string $name, bool $identical = true): bool
     {
-        if (!isset($this->oldAttributes[$name])) {
-            return array_key_exists($name, $this->getObjectVars($this));
+        $attributes = $this->getAttributesInternal();
+
+        if (empty($this->oldAttributes) || !array_key_exists($name, $this->oldAttributes)) {
+            return array_key_exists($name, $attributes);
         }
 
-        return $this->getAttribute($name) !== $this->oldAttributes[$name];
+        return !array_key_exists($name, $attributes) || $attributes[$name] !== $this->oldAttributes[$name];
     }
 
     public function isPrimaryKey(array $keys): bool
@@ -674,7 +670,7 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
      */
     public function setIsNewRecord(bool $value): void
     {
-        $this->oldAttributes = $value ? null : $this->getObjectVars($this);
+        $this->oldAttributes = $value ? null : $this->getAttributesInternal();
     }
 
     /**

--- a/src/BaseActiveRecord.php
+++ b/src/BaseActiveRecord.php
@@ -230,9 +230,9 @@ class BaseActiveRecord extends AbstractActiveRecord
         return $columnNames;
     }
 
-    protected function getObjectVars(ActiveRecordInterface $object): array
+    protected function getAttributesInternal(): array
     {
-        return get_object_vars($object);
+        return get_object_vars($this);
     }
 
     protected function insertInternal(array $attributes = null): bool

--- a/src/Trait/MagicPropertiesTrait.php
+++ b/src/Trait/MagicPropertiesTrait.php
@@ -14,10 +14,6 @@ use Yiisoft\Db\Exception\InvalidCallException;
 use Yiisoft\Db\Exception\InvalidConfigException;
 use Yiisoft\Db\Exception\UnknownPropertyException;
 
-use function array_diff;
-use function array_flip;
-use function array_intersect_key;
-use function array_key_exists;
 use function array_merge;
 use function get_object_vars;
 use function in_array;
@@ -54,6 +50,7 @@ use function ucfirst;
  */
 trait MagicPropertiesTrait
 {
+    /** @psalm-var array<string, mixed> $attributes */
     private array $attributes = [];
 
     /**
@@ -171,47 +168,9 @@ trait MagicPropertiesTrait
         throw new UnknownPropertyException('Setting unknown property: ' . static::class . '::' . $name);
     }
 
-    public function getAttribute(string $name): mixed
-    {
-        if ($name !== 'attributes' && property_exists($this, $name)) {
-            return get_object_vars($this)[$name] ?? null;
-        }
-
-        return $this->attributes[$name] ?? null;
-    }
-
-    public function getAttributes(array|null $names = null, array $except = []): array
-    {
-        $names ??= $this->attributes();
-        $attributes = array_merge($this->attributes, get_object_vars($this));
-
-        if (!empty($except)) {
-            $names = array_diff($names, $except);
-        }
-
-        return array_intersect_key($attributes, array_flip($names));
-    }
-
     public function hasAttribute(string $name): bool
     {
         return isset($this->attributes[$name]) || in_array($name, $this->attributes(), true);
-    }
-
-    public function isAttributeChanged(string $name, bool $identical = true): bool
-    {
-        $hasOldAttribute = array_key_exists($name, $this->getOldAttributes());
-
-        if (!$hasOldAttribute) {
-            return property_exists($this, $name) && array_key_exists($name, get_object_vars($this))
-                || array_key_exists($name, $this->attributes);
-        }
-
-        if (property_exists($this, $name)) {
-            return $this->getOldAttribute($name) !== $this->$name;
-        }
-
-        return !array_key_exists($name, $this->attributes)
-            || $this->getOldAttribute($name) !== $this->attributes[$name];
     }
 
     public function setAttribute(string $name, mixed $value): void
@@ -262,6 +221,12 @@ trait MagicPropertiesTrait
         return method_exists($this, 'set' . ucfirst($name))
             || ($checkVars && property_exists($this, $name))
             || $this->hasAttribute($name);
+    }
+
+    /** @psalm-return array<string, mixed> */
+    protected function getAttributesInternal(): array
+    {
+        return array_merge($this->attributes, parent::getAttributesInternal());
     }
 
     protected function populateAttribute(string $name, mixed $value): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #308 
