### PR TITLE
Make `ActiveQuery::getARClassName()` private

### DIFF
--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -976,19 +976,6 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         return $this;
     }
 
-    public function getARClassName(): string
-    {
-        if ($this->arClass instanceof ActiveRecordInterface) {
-            return $this->arClass::class;
-        }
-
-        if ($this->arClass instanceof Closure) {
-            return ($this->arClass)($this->db)::class;
-        }
-
-        return $this->arClass;
-    }
-
     public function getARInstance(): ActiveRecordInterface
     {
         if ($this->arClass instanceof ActiveRecordInterface) {
@@ -1003,6 +990,19 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         $class = $this->arClass;
 
         return new $class($this->db, $this->tableName);
+    }
+
+    private function getARClassName(): string
+    {
+        if ($this->arClass instanceof ActiveRecordInterface) {
+            return $this->arClass::class;
+        }
+
+        if ($this->arClass instanceof Closure) {
+            return ($this->arClass)($this->db)::class;
+        }
+
+        return $this->arClass;
     }
 
     private function createInstance(): static

--- a/tests/ActiveQueryTest.php
+++ b/tests/ActiveQueryTest.php
@@ -2671,7 +2671,7 @@ abstract class ActiveQueryTest extends TestCase
         $query = new ActiveQuery(Customer::class, $this->db);
 
         $this->assertSame($query->getARClass(), Customer::class);
-        $this->assertSame($query->getARClassName(), Customer::class);
+        $this->assertSame(Assert::invokeMethod($query, 'getARClassName'), Customer::class);
         $this->assertInstanceOf(Customer::class, $query->getARInstance());
     }
 
@@ -2681,7 +2681,7 @@ abstract class ActiveQueryTest extends TestCase
         $query = new ActiveQuery($customer, $this->db);
 
         $this->assertSame($query->getARClass(), $customer);
-        $this->assertSame($query->getARClassName(), Customer::class);
+        $this->assertSame(Assert::invokeMethod($query, 'getARClassName'), Customer::class);
         $this->assertInstanceOf(Customer::class, $query->getARInstance());
     }
 
@@ -2691,7 +2691,7 @@ abstract class ActiveQueryTest extends TestCase
         $query = new ActiveQuery($closure, $this->db);
 
         $this->assertSame($query->getARClass(), $closure);
-        $this->assertSame($query->getARClassName(), Customer::class);
+        $this->assertSame(Assert::invokeMethod($query, 'getARClassName'), Customer::class);
         $this->assertInstanceOf(Customer::class, $query->getARInstance());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -