### PR TITLE
Remove `onePopulate()` and `allPopulate()` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ use Yiisoft\ActiveRecord\ActiveQuery;
 
 $userQuery = new ActiveQuery(User::class);
 
-$user = $userQuery->where(['id' => 1])->onePopulate();
+$user = $userQuery->where(['id' => 1])->one();
 
 $username = $user->getAttribute('username');
 $email = $user->getAttribute('email');

--- a/docs/create-model.md
+++ b/docs/create-model.md
@@ -284,7 +284,7 @@ use Yiisoft\ActiveRecord\ActiveQuery;
 
 $userQuery = new ActiveQuery(User::class, $db);
 
-$user = $userQuery->where(['id' => 1])->onePopulate();
+$user = $userQuery->where(['id' => 1])->one();
 
 $profile = $user->getProfile();
 $orders = $user->getOrders();

--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -121,18 +121,6 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         parent::__construct($this->getARInstance()->db());
     }
 
-    /**
-     * Executes a query and returns all results as an array.
-     *
-     * If null, the db connection returned by {@see arClass} will be used.
-     *
-     * @throws Exception
-     * @throws InvalidConfigException
-     * @throws Throwable
-     *
-     * @psalm-suppress ImplementedReturnTypeMismatch
-     * @return ActiveRecordInterface[] The query results. If the query results in nothing, an empty array will be returned.
-     */
     public function all(): array
     {
         if ($this->shouldEmulateExecution()) {
@@ -213,11 +201,11 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                     }
                 } else {
                     if ($viaCallableUsed) {
-                        $model = $viaQuery->onePopulate();
+                        $model = $viaQuery->one();
                     } elseif ($this->primaryModel->isRelationPopulated($viaName)) {
                         $model = $this->primaryModel->relation($viaName);
                     } else {
-                        $model = $viaQuery->onePopulate();
+                        $model = $viaQuery->one();
                         $this->primaryModel->populateRelation($viaName, $model);
                     }
                     $viaModels = $model === null ? [] : [$model];
@@ -337,43 +325,15 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         return array_values(array_combine($hash, $models));
     }
 
-    /**
-     * @throws Exception
-     * @throws InvalidArgumentException
-     * @throws InvalidConfigException
-     * @throws NotSupportedException
-     * @throws ReflectionException
-     * @throws Throwable
-     */
-    public function allPopulate(): array
+    public function one(): array|ActiveRecordInterface|null
     {
-        $rows = $this->all();
+        $row = parent::one();
 
-        if ($rows !== []) {
-            $rows = $this->populate($rows, $this->indexBy);
+        if ($row === null) {
+            return null;
         }
 
-        return $rows;
-    }
-
-    /**
-     * @throws Exception
-     * @throws InvalidArgumentException
-     * @throws InvalidConfigException
-     * @throws NotSupportedException
-     * @throws ReflectionException
-     * @throws Throwable
-     */
-    public function onePopulate(): array|ActiveRecordInterface|null
-    {
-        $row = $this->one();
-
-        if ($row !== null) {
-            $activeRecord = $this->populate([$row], $this->indexBy);
-            $row = reset($activeRecord) ?: null;
-        }
-
-        return $row;
+        return $this->populate([$row])[0];
     }
 
     /**
@@ -883,7 +843,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      */
     public function findOne(mixed $condition): array|ActiveRecordInterface|null
     {
-        return $this->findByCondition($condition)->onePopulate();
+        return $this->findByCondition($condition)->one();
     }
 
     /**

--- a/src/ActiveQueryInterface.php
+++ b/src/ActiveQueryInterface.php
@@ -10,6 +10,7 @@ use Throwable;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidArgumentException;
 use Yiisoft\Db\Exception\InvalidConfigException;
+use Yiisoft\Db\Exception\NotSupportedException;
 use Yiisoft\Db\Query\QueryInterface;
 use Yiisoft\Definitions\Exception\CircularReferenceException;
 use Yiisoft\Definitions\Exception\NotInstantiableException;
@@ -26,6 +27,19 @@ use Yiisoft\Definitions\Exception\NotInstantiableException;
  */
 interface ActiveQueryInterface extends QueryInterface
 {
+    /**
+     * @inheritdoc
+     *
+     * @return array[]|ActiveRecordInterface[] All rows of the query result. Each array element is an `array` or
+     * instance of {@see ActiveRecordInterface} representing a row of data, depends on {@see asArray(), isAsArray()}
+     * value. Empty array if the query results in nothing.
+     *
+     * @throws Exception
+     * @throws InvalidConfigException
+     * @throws Throwable
+     */
+    public function all(): array;
+
     /**
      * Sets the {@see asArray} property.
      *
@@ -544,23 +558,10 @@ interface ActiveQueryInterface extends QueryInterface
      *
      * @param bool $value Whether this query represents a relation to more than one record.
      * This property is only used in relational context. If true, this relation will populate all query results into AR
-     * instances using {@see Query::all()|all()}.
-     * If false, only the first row of the results will be retrieved using {@see Query::one()|one()}.
+     * instances using {@see all()}.
+     * If false, only the first row of the results will be retrieved using {@see one()}.
      */
     public function multiple(bool $value): self;
-
-    /**
-     * Executes the query and returns ActiveRecord instances populated with the query result.
-     *
-     * @return ActiveRecordInterface|array|null The query results. If the query results in nothing, an empty array will
-     * be returned.
-     */
-    public function allPopulate(): array|ActiveRecordInterface|null;
-
-    /**
-     * Executes the query and returns ActiveRecord instances populated with the query result.
-     */
-    public function onePopulate(): array|ActiveRecordInterface|null;
 
     /**
      * @return ActiveQueryInterface|array|null The query associated with the junction table.
@@ -599,9 +600,24 @@ interface ActiveQueryInterface extends QueryInterface
      * This property is only used in relational context.
      *
      * If `true`, this relation will populate all query results into active record instances using
-     * {@see ActiveQuery::all()}.
+     * {@see all()}.
      *
-     * If `false`, only the first row of the results will be retrieved using {@see ActiveQuery::one()}.
+     * If `false`, only the first row of the results will be retrieved using {@see one()}.
      */
     public function getMultiple(): bool;
+
+    /**
+     * @inheritdoc
+     *
+     * @return array|ActiveRecordInterface|null The first row as an `array` or instance of {@see ActiveRecordInterface}
+     * of the query result, depends on {@see asArray(), isAsArray()} value. `null` if the query results in nothing.
+     *
+     * @throws Exception
+     * @throws InvalidArgumentException
+     * @throws InvalidConfigException
+     * @throws NotSupportedException
+     * @throws ReflectionException
+     * @throws Throwable
+     */
+    public function one(): array|ActiveRecordInterface|null;
 }

--- a/src/ActiveQueryInterface.php
+++ b/src/ActiveQueryInterface.php
@@ -34,7 +34,7 @@ interface ActiveQueryInterface extends QueryInterface
      * @throws InvalidConfigException
      * @throws Throwable
      *
-     * @return array[]|ActiveRecordInterface[] All rows of the query result. Each array element is an `array` or
+     * @return ActiveRecordInterface[]|array[] All rows of the query result. Each array element is an `array` or
      * instance of {@see ActiveRecordInterface} representing a row of data, depends on {@see isAsArray()} result.
      * Empty array if the query results in nothing.
      */
@@ -616,7 +616,7 @@ interface ActiveQueryInterface extends QueryInterface
      * @throws ReflectionException
      * @throws Throwable
      *
-     * @return array|ActiveRecordInterface|null The first row as an `array` or instance of {@see ActiveRecordInterface}
+     * @return ActiveRecordInterface|array|null The first row as an `array` or instance of {@see ActiveRecordInterface}
      * of the query result, depends on {@see isAsArray()} result. `null` if the query results in nothing.
      */
     public function one(): array|ActiveRecordInterface|null;

--- a/src/ActiveQueryInterface.php
+++ b/src/ActiveQueryInterface.php
@@ -31,8 +31,8 @@ interface ActiveQueryInterface extends QueryInterface
      * @inheritdoc
      *
      * @return array[]|ActiveRecordInterface[] All rows of the query result. Each array element is an `array` or
-     * instance of {@see ActiveRecordInterface} representing a row of data, depends on {@see asArray(), isAsArray()}
-     * value. Empty array if the query results in nothing.
+     * instance of {@see ActiveRecordInterface} representing a row of data, depends on {@see isAsArray()} result.
+     * Empty array if the query results in nothing.
      *
      * @throws Exception
      * @throws InvalidConfigException
@@ -610,7 +610,7 @@ interface ActiveQueryInterface extends QueryInterface
      * @inheritdoc
      *
      * @return array|ActiveRecordInterface|null The first row as an `array` or instance of {@see ActiveRecordInterface}
-     * of the query result, depends on {@see asArray(), isAsArray()} value. `null` if the query results in nothing.
+     * of the query result, depends on {@see isAsArray()} result. `null` if the query results in nothing.
      *
      * @throws Exception
      * @throws InvalidArgumentException

--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -204,7 +204,7 @@ class ActiveRecord extends AbstractActiveRecord
 
         $query->where($pk);
 
-        return $this->refreshInternal($query->onePopulate());
+        return $this->refreshInternal($query->one());
     }
 
     /**

--- a/src/ActiveRelationTrait.php
+++ b/src/ActiveRelationTrait.php
@@ -185,7 +185,7 @@ trait ActiveRelationTrait
      */
     public function relatedRecords(): ActiveRecordInterface|array|null
     {
-        return $this->multiple ? $this->all() : $this->onePopulate();
+        return $this->multiple ? $this->all() : $this->one();
     }
 
     /**
@@ -254,7 +254,7 @@ trait ActiveRelationTrait
         }
 
         if (!$this->multiple && count($primaryModels) === 1) {
-            $models = [$this->onePopulate()];
+            $models = [$this->one()];
             $this->populateInverseRelation($models, $primaryModels);
 
             $primaryModel = reset($primaryModels);

--- a/tests/ActiveQueryFindTest.php
+++ b/tests/ActiveQueryFindTest.php
@@ -77,19 +77,19 @@ abstract class ActiveQueryFindTest extends TestCase
 
         $customerQuery = new ActiveQuery(Customer::class);
 
-        /** find onePopulate */
-        $customers = $customerQuery->findBySql('SELECT * FROM {{customer}} ORDER BY [[id]] DESC')->onePopulate();
+        /** find one() */
+        $customers = $customerQuery->findBySql('SELECT * FROM {{customer}} ORDER BY [[id]] DESC')->one();
         $this->assertInstanceOf(Customer::class, $customers);
         $this->assertEquals('user3', $customers->getAttribute('name'));
 
-        /** find allPopulate */
-        $customers = $customerQuery->findBySql('SELECT * FROM {{customer}}')->allPopulate();
+        /** find all() */
+        $customers = $customerQuery->findBySql('SELECT * FROM {{customer}}')->all();
         $this->assertCount(3, $customers);
 
         /** find with parameter binding */
         $customers = $customerQuery
             ->findBySql('SELECT * FROM {{customer}} WHERE [[id]]=:id', [':id' => 2])
-            ->onePopulate();
+            ->one();
         $this->assertInstanceOf(Customer::class, $customers);
         $this->assertEquals('user2', $customers->getAttribute('name'));
     }
@@ -210,12 +210,12 @@ abstract class ActiveQueryFindTest extends TestCase
         $this->assertInstanceOf(ActiveQueryInterface::class, $customerQuery);
 
         /** find one */
-        $customer = $customerQuery->onePopulate();
+        $customer = $customerQuery->one();
         $this->assertInstanceOf(Customer::class, $customer);
 
         /** find all */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customers = $customerQuery->allPopulate();
+        $customers = $customerQuery->all();
         $this->assertCount(3, $customers);
         $this->assertInstanceOf(Customer::class, $customers[0]);
         $this->assertInstanceOf(Customer::class, $customers[1]);
@@ -254,13 +254,13 @@ abstract class ActiveQueryFindTest extends TestCase
 
         /** find by attributes */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->where(['name' => 'user2'])->onePopulate();
+        $customer = $customerQuery->where(['name' => 'user2'])->one();
         $this->assertInstanceOf(Customer::class, $customer);
         $this->assertEquals(2, $customer->getId());
 
         /** scope */
         $customerQuery = new CustomerQuery(Customer::class);
-        $this->assertCount(2, $customerQuery->active()->allPopulate());
+        $this->assertCount(2, $customerQuery->active()->all());
         $this->assertEquals(2, $customerQuery->active()->count());
     }
 
@@ -397,48 +397,48 @@ abstract class ActiveQueryFindTest extends TestCase
 
         /** one */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->orderBy('id')->onePopulate();
+        $customer = $customerQuery->orderBy('id')->one();
         $this->assertEquals('user1', $customer->getName());
 
         /** all */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customers = $customerQuery->allPopulate();
+        $customers = $customerQuery->all();
         $this->assertCount(3, $customers);
 
         /** limit */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customers = $customerQuery->orderBy('id')->limit(1)->allPopulate();
+        $customers = $customerQuery->orderBy('id')->limit(1)->all();
         $this->assertCount(1, $customers);
         $this->assertEquals('user1', $customers[0]->getName());
 
-        $customers = $customerQuery->orderBy('id')->limit(1)->offset(1)->allPopulate();
+        $customers = $customerQuery->orderBy('id')->limit(1)->offset(1)->all();
         $this->assertCount(1, $customers);
         $this->assertEquals('user2', $customers[0]->getName());
 
-        $customers = $customerQuery->orderBy('id')->limit(1)->offset(2)->allPopulate();
+        $customers = $customerQuery->orderBy('id')->limit(1)->offset(2)->all();
         $this->assertCount(1, $customers);
         $this->assertEquals('user3', $customers[0]->getName());
 
-        $customers = $customerQuery->orderBy('id')->limit(2)->offset(1)->allPopulate();
+        $customers = $customerQuery->orderBy('id')->limit(2)->offset(1)->all();
         $this->assertCount(2, $customers);
         $this->assertEquals('user2', $customers[0]->getName());
         $this->assertEquals('user3', $customers[1]->getName());
 
-        $customers = $customerQuery->limit(2)->offset(3)->allPopulate();
+        $customers = $customerQuery->limit(2)->offset(3)->all();
         $this->assertCount(0, $customers);
 
         /** offset */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->orderBy('id')->offset(0)->onePopulate();
+        $customer = $customerQuery->orderBy('id')->offset(0)->one();
         $this->assertEquals('user1', $customer->getName());
 
-        $customer = $customerQuery->orderBy('id')->offset(1)->onePopulate();
+        $customer = $customerQuery->orderBy('id')->offset(1)->one();
         $this->assertEquals('user2', $customer->getName());
 
-        $customer = $customerQuery->orderBy('id')->offset(2)->onePopulate();
+        $customer = $customerQuery->orderBy('id')->offset(2)->one();
         $this->assertEquals('user3', $customer->getName());
 
-        $customer = $customerQuery->offset(3)->onePopulate();
+        $customer = $customerQuery->offset(3)->one();
         $this->assertNull($customer);
     }
 
@@ -513,7 +513,7 @@ abstract class ActiveQueryFindTest extends TestCase
         $customers[1]->resetRelation('orders');
         $this->assertFalse($customers[1]->isRelationPopulated('orders'));
 
-        $customer = $customerQuery->where(['id' => 1])->with('orders')->onePopulate();
+        $customer = $customerQuery->where(['id' => 1])->with('orders')->one();
         $this->assertTrue($customer->isRelationPopulated('orders'));
         $this->assertCount(1, $customer->getOrders());
         $this->assertCount(1, $customer->getRelatedRecords());
@@ -569,7 +569,7 @@ abstract class ActiveQueryFindTest extends TestCase
         $this->assertCount(3, $customers[2]->getOrders()[0]->getItems());
         $this->assertCount(1, $customers[2]->getOrders()[1]->getItems());
 
-        $customers = $customerQuery->where(['id' => 1])->with('ordersWithItems')->onePopulate();
+        $customers = $customerQuery->where(['id' => 1])->with('ordersWithItems')->one();
         $this->assertTrue($customers->isRelationPopulated('ordersWithItems'));
         $this->assertCount(1, $customers->getOrdersWithItems());
 
@@ -667,7 +667,7 @@ abstract class ActiveQueryFindTest extends TestCase
         $this->checkFixture($this->db(), 'order');
 
         $orderQuery = new ActiveQuery(Order::class);
-        $order = $orderQuery->with('itemsIndexed')->where(['id' => 1])->onePopulate();
+        $order = $orderQuery->with('itemsIndexed')->where(['id' => 1])->one();
         $this->assertTrue($order->isRelationPopulated('itemsIndexed'));
 
         $items = $order->getItemsIndexed();
@@ -675,7 +675,7 @@ abstract class ActiveQueryFindTest extends TestCase
         $this->assertTrue(isset($items[1]));
         $this->assertTrue(isset($items[2]));
 
-        $order = $orderQuery->with('itemsIndexed')->where(['id' => 2])->onePopulate();
+        $order = $orderQuery->with('itemsIndexed')->where(['id' => 2])->one();
         $this->assertTrue($order->isRelationPopulated('itemsIndexed'));
 
         $items = $order->getItemsIndexed();

--- a/tests/ActiveQueryTest.php
+++ b/tests/ActiveQueryTest.php
@@ -76,25 +76,25 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertEquals($rows, $result);
     }
 
-    public function testAllPopulate(): void
+    public function testAll(): void
     {
         $this->checkFixture($this->db(), 'customer');
 
         $query = new ActiveQuery(Customer::class);
 
-        foreach ($query->allPopulate() as $customer) {
+        foreach ($query->all() as $customer) {
             $this->assertInstanceOf(Customer::class, $customer);
         }
 
-        $this->assertCount(3, $query->allPopulate());
+        $this->assertCount(3, $query->all());
     }
 
-    public function testOnePopulate(): void
+    public function testOne(): void
     {
         $this->checkFixture($this->db(), 'customer');
 
         $query = new ActiveQuery(Customer::class);
-        $this->assertInstanceOf(Customer::class, $query->onePopulate());
+        $this->assertInstanceOf(Customer::class, $query->one());
     }
 
     public function testCreateCommand(): void
@@ -365,11 +365,11 @@ abstract class ActiveQueryTest extends TestCase
         if ($this->db()->getDriverName() === 'oci') {
             $customers = $customerQuery
                 ->select(['{{customer}}.*', '([[status]]*2) AS [[status2]]'])
-                ->where(['name' => 'user3'])->onePopulate();
+                ->where(['name' => 'user3'])->one();
         } else {
             $customers = $customerQuery
                 ->select(['*', '([[status]]*2) AS [[status2]]'])
-                ->where(['name' => 'user3'])->onePopulate();
+                ->where(['name' => 'user3'])->one();
         }
 
         $this->assertEquals(3, $customers->getAttribute('id'));
@@ -438,7 +438,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $categoryQuery = new ActiveQuery(Category::class);
 
-        $categories = $categoryQuery->where(['id' => 1])->onePopulate();
+        $categories = $categoryQuery->where(['id' => 1])->one();
         $this->assertNotNull($categories);
 
         $orders = $categories->getOrders();
@@ -450,7 +450,7 @@ abstract class ActiveQueryTest extends TestCase
         sort($ids);
         $this->assertEquals([1, 3], $ids);
 
-        $categories = $categoryQuery->where(['id' => 2])->onePopulate();
+        $categories = $categoryQuery->where(['id' => 2])->one();
         $this->assertNotNull($categories);
 
         $orders = $categories->getOrders();
@@ -668,7 +668,7 @@ abstract class ActiveQueryTest extends TestCase
                     $q->orderBy([]);
                 },
             ]
-        )->onePopulate();
+        )->one();
         $this->assertEquals(1, $customer->getId());
 
         $orderQuery = new ActiveQuery(Order::class);
@@ -983,11 +983,11 @@ abstract class ActiveQueryTest extends TestCase
         $customerQuery = $order->getCustomerQuery()->innerJoinWith(['orders o'], false);
 
         if ($aliasMethod === 'explicit') {
-            $customer = $customerQuery->where(['o.id' => 1])->onePopulate();
+            $customer = $customerQuery->where(['o.id' => 1])->one();
         } elseif ($aliasMethod === 'querysyntax') {
-            $customer = $customerQuery->where(['{{@order}}.id' => 1])->onePopulate();
+            $customer = $customerQuery->where(['{{@order}}.id' => 1])->one();
         } elseif ($aliasMethod === 'applyAlias') {
-            $customer = $customerQuery->where([$query->applyAlias('order', 'id') => 1])->onePopulate();
+            $customer = $customerQuery->where([$query->applyAlias('order', 'id') => 1])->one();
         }
 
         $this->assertEquals(1, $customer->getId());
@@ -1380,7 +1380,7 @@ abstract class ActiveQueryTest extends TestCase
 
         /** eager loading: find one and all */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->with('orders2')->where(['id' => 1])->onePopulate();
+        $customer = $customerQuery->with('orders2')->where(['id' => 1])->one();
         $this->assertSame($customer->getOrders2()[0]->getCustomer2(), $customer);
 
         //$customerQuery = new ActiveQuery(Customer::class);
@@ -1414,7 +1414,7 @@ abstract class ActiveQueryTest extends TestCase
 
         /** the other way around */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->with('orders2')->where(['id' => 1])->asArray()->onePopulate();
+        $customer = $customerQuery->with('orders2')->where(['id' => 1])->asArray()->one();
         $this->assertSame($customer['orders2'][0]['customer2']['id'], $customer['id']);
 
         $customerQuery = new ActiveQuery(Customer::class);
@@ -1427,7 +1427,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertSame($orders[0]->getCustomer2()->getOrders2(), [$orders[0]]);
 
         $orderQuery = new ActiveQuery(Order::class);
-        $order = $orderQuery->with('customer2')->where(['id' => 1])->onePopulate();
+        $order = $orderQuery->with('customer2')->where(['id' => 1])->one();
         $this->assertSame($order->getCustomer2()->getOrders2(), [$order]);
 
         $orderQuery = new ActiveQuery(Order::class);
@@ -1435,7 +1435,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertSame($orders[0]['customer2']['orders2'][0]['id'], $orders[0]['id']);
 
         $orderQuery = new ActiveQuery(Order::class);
-        $order = $orderQuery->with('customer2')->where(['id' => 1])->asArray()->onePopulate();
+        $order = $orderQuery->with('customer2')->where(['id' => 1])->asArray()->one();
         $this->assertSame($order['customer2']['orders2'][0]['id'], $orders[0]['id']);
 
         $orderQuery = new ActiveQuery(Order::class);
@@ -1663,7 +1663,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->checkFixture($this->db(), 'order');
 
         $orderQuery = new ActiveQuery(Order::class);
-        $order = $orderQuery->with('orderItems2')->where(['id' => 1])->onePopulate();
+        $order = $orderQuery->with('orderItems2')->where(['id' => 1])->one();
 
         $orderItem = new OrderItem();
 
@@ -1713,7 +1713,7 @@ abstract class ActiveQueryTest extends TestCase
         /**
          * Ensure that limitedItems relation returns only one item (category_id = 2 and id in (1,2,3))
          */
-        $category = $categoryQuery->onePopulate();
+        $category = $categoryQuery->one();
         $this->assertCount(1, $category->getLimitedItems());
 
         /** Unlink all items in the limitedItems relation */
@@ -1724,7 +1724,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertEquals(2, $itemsCount);
 
         /** Call $categoryQuery again to ensure no items were found */
-        $this->assertCount(0, $categoryQuery->onePopulate()->getLimitedItems());
+        $this->assertCount(0, $categoryQuery->one()->getLimitedItems());
     }
 
     /**
@@ -1745,14 +1745,14 @@ abstract class ActiveQueryTest extends TestCase
         /**
          * Ensure that limitedItems relation returns only one item (category_id = 2 and id in (4, 5)).
          */
-        $category = $orderQuery->onePopulate();
+        $category = $orderQuery->one();
         $this->assertCount(2, $category->getLimitedItems());
 
         /** Unlink all items in the limitedItems relation */
         $category->unlinkAll('limitedItems', true);
 
         /** Call $orderQuery again to ensure that links are removed */
-        $this->assertCount(0, $orderQuery->onePopulate()->getLimitedItems());
+        $this->assertCount(0, $orderQuery->one()->getLimitedItems());
 
         /** Make sure that only links were removed, the items were not removed */
         $this->assertEquals(3, $itemQuery->where(['category_id' => 2])->count());
@@ -1818,7 +1818,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $customerQuery = new ActiveQuery(Customer::class);
 
-        $query = $customerQuery->with('orders2')->where(['id' => 1])->onePopulate();
+        $query = $customerQuery->with('orders2')->where(['id' => 1])->one();
         $this->assertCount(1, $query->getRelatedRecords());
         $this->assertCount(1, $query->extraFields());
         $this->assertArrayHasKey('orders2', $query->getRelatedRecords());
@@ -1975,7 +1975,7 @@ abstract class ActiveQueryTest extends TestCase
         $orders2 = $customer->getOrders2Query()->all();
         $this->assertSame($customer, $orders2[0]->getCustomer2());
 
-        $orders2 = $customer->getOrders2Query()->onePopulate();
+        $orders2 = $customer->getOrders2Query()->one();
         $this->assertSame($customer, $orders2->getCustomer2());
 
         /**
@@ -1985,14 +1985,14 @@ abstract class ActiveQueryTest extends TestCase
         $orders2 = $customer->getOrders2Query()->with('customer2')->all();
         $this->assertSame($customer, $orders2[0]->getCustomer2());
 
-        $orders2 = $customer->getOrders2Query()->with('customer2')->onePopulate();
+        $orders2 = $customer->getOrders2Query()->with('customer2')->one();
         $this->assertSame($customer, $orders2->getCustomer2());
 
         /** request the inverseOf relation as array */
         $orders2 = $customer->getOrders2Query()->asArray()->all();
         $this->assertEquals($customer->getId(), $orders2[0]['customer2']->getId());
 
-        $orders2 = $customer->getOrders2Query()->asArray()->onePopulate();
+        $orders2 = $customer->getOrders2Query()->asArray()->one();
         $this->assertEquals($customer->getId(), $orders2['customer2']->getId());
     }
 

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -204,7 +204,7 @@ abstract class ActiveRecordTest extends TestCase
 
         /** @var $model Type */
         $aqClass = new ActiveQuery(Type::class);
-        $query = $aqClass->onePopulate();
+        $query = $aqClass->one();
 
         $this->assertSame(123, $query->int_col);
         $this->assertSame(456, $query->int_col2);
@@ -226,10 +226,10 @@ abstract class ActiveRecordTest extends TestCase
 
         $animal = new ActiveQuery(Animal::class);
 
-        $animals = $animal->where(['type' => Dog::class])->onePopulate();
+        $animals = $animal->where(['type' => Dog::class])->one();
         $this->assertEquals('bark', $animals->getDoes());
 
-        $animals = $animal->where(['type' => Cat::class])->onePopulate();
+        $animals = $animal->where(['type' => Cat::class])->one();
         $this->assertEquals('meow', $animals->getDoes());
     }
 

--- a/tests/Driver/Mysql/ActiveRecordTest.php
+++ b/tests/Driver/Mysql/ActiveRecordTest.php
@@ -46,7 +46,7 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
 
         /** @var $model Type */
         $aqClass = new ActiveQuery(Type::class);
-        $query = $aqClass->onePopulate();
+        $query = $aqClass->one();
 
         $this->assertSame(123, $query->int_col);
         $this->assertSame(456, $query->int_col2);

--- a/tests/Driver/Oracle/ActiveQueryFindTest.php
+++ b/tests/Driver/Oracle/ActiveQueryFindTest.php
@@ -24,48 +24,48 @@ final class ActiveQueryFindTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryF
 
         /** one */
         $customerQuery = new ActiveQuery(CustomerWithRownumid::class);
-        $customer = $customerQuery->orderBy('id')->onePopulate();
+        $customer = $customerQuery->orderBy('id')->one();
         $this->assertEquals('user1', $customer->getName());
 
         /** all */
         $customerQuery = new ActiveQuery(CustomerWithRownumid::class);
-        $customers = $customerQuery->allPopulate();
+        $customers = $customerQuery->all();
         $this->assertCount(3, $customers);
 
         /** limit */
         $customerQuery = new ActiveQuery(CustomerWithRownumid::class);
-        $customers = $customerQuery->orderBy('id')->limit(1)->allPopulate();
+        $customers = $customerQuery->orderBy('id')->limit(1)->all();
         $this->assertCount(1, $customers);
         $this->assertEquals('user1', $customers[0]->getName());
 
-        $customers = $customerQuery->orderBy('id')->limit(1)->offset(1)->allPopulate();
+        $customers = $customerQuery->orderBy('id')->limit(1)->offset(1)->all();
         $this->assertCount(1, $customers);
         $this->assertEquals('user2', $customers[0]->getName());
 
-        $customers = $customerQuery->orderBy('id')->limit(1)->offset(2)->allPopulate();
+        $customers = $customerQuery->orderBy('id')->limit(1)->offset(2)->all();
         $this->assertCount(1, $customers);
         $this->assertEquals('user3', $customers[0]->getName());
 
-        $customers = $customerQuery->orderBy('id')->limit(2)->offset(1)->allPopulate();
+        $customers = $customerQuery->orderBy('id')->limit(2)->offset(1)->all();
         $this->assertCount(2, $customers);
         $this->assertEquals('user2', $customers[0]->getName());
         $this->assertEquals('user3', $customers[1]->getName());
 
-        $customers = $customerQuery->limit(2)->offset(3)->allPopulate();
+        $customers = $customerQuery->limit(2)->offset(3)->all();
         $this->assertCount(0, $customers);
 
         /** offset */
         $customerQuery = new ActiveQuery(CustomerWithRownumid::class);
-        $customer = $customerQuery->orderBy('id')->offset(0)->onePopulate();
+        $customer = $customerQuery->orderBy('id')->offset(0)->one();
         $this->assertEquals('user1', $customer->getName());
 
-        $customer = $customerQuery->orderBy('id')->offset(1)->onePopulate();
+        $customer = $customerQuery->orderBy('id')->offset(1)->one();
         $this->assertEquals('user2', $customer->getName());
 
-        $customer = $customerQuery->orderBy('id')->offset(2)->onePopulate();
+        $customer = $customerQuery->orderBy('id')->offset(2)->one();
         $this->assertEquals('user3', $customer->getName());
 
-        $customer = $customerQuery->offset(3)->onePopulate();
+        $customer = $customerQuery->offset(3)->one();
         $this->assertNull($customer);
     }
 
@@ -88,7 +88,7 @@ final class ActiveQueryFindTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryF
         $customers[1]->resetRelation('orders');
         $this->assertFalse($customers[1]->isRelationPopulated('orders'));
 
-        $customer = $customerQuery->where(['id' => 1])->with('orders')->onePopulate();
+        $customer = $customerQuery->where(['id' => 1])->with('orders')->one();
         $this->assertTrue($customer->isRelationPopulated('orders'));
         $this->assertCount(1, $customer->getOrders());
         $this->assertCount(1, $customer->getRelatedRecords());
@@ -112,7 +112,7 @@ final class ActiveQueryFindTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryF
 
         /** asArray */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->where(['[[id]]' => 2])->asArray()->onePopulate();
+        $customer = $customerQuery->where(['[[id]]' => 2])->asArray()->one();
         $this->assertEquals([
             'id' => 2,
             'email' => 'user2@example.com',

--- a/tests/Driver/Oracle/ActiveQueryTest.php
+++ b/tests/Driver/Oracle/ActiveQueryTest.php
@@ -228,11 +228,11 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
         $customerQuery = $order->getCustomerQuery()->innerJoinWith(['orders o'], false);
 
         if ($aliasMethod === 'explicit') {
-            $customer = $customerQuery->where(['{{o}}.[[id]]' => 1])->onePopulate();
+            $customer = $customerQuery->where(['{{o}}.[[id]]' => 1])->one();
         } elseif ($aliasMethod === 'querysyntax') {
-            $customer = $customerQuery->where(['{{@order}}.id' => 1])->onePopulate();
+            $customer = $customerQuery->where(['{{@order}}.id' => 1])->one();
         } elseif ($aliasMethod === 'applyAlias') {
-            $customer = $customerQuery->where([$query->applyAlias('order', 'id') => 1])->onePopulate();
+            $customer = $customerQuery->where([$query->applyAlias('order', 'id') => 1])->one();
         }
 
         $this->assertEquals(1, $customer->getId());

--- a/tests/Driver/Oracle/ActiveRecordTest.php
+++ b/tests/Driver/Oracle/ActiveRecordTest.php
@@ -45,7 +45,7 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
         $arClass->save();
 
         $aqClass = new ActiveQuery(Type::class);
-        $query = $aqClass->onePopulate();
+        $query = $aqClass->one();
 
         $this->assertSame(123, $query->int_col);
         $this->assertSame(456, $query->int_col2);

--- a/tests/Driver/Oracle/MagicActiveRecordTest.php
+++ b/tests/Driver/Oracle/MagicActiveRecordTest.php
@@ -39,7 +39,7 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
         $arClass->save();
 
         $aqClass = new ActiveQuery(Type::class);
-        $query = $aqClass->onePopulate();
+        $query = $aqClass->one();
 
         $this->assertSame(123, $query->int_col);
         $this->assertSame(456, $query->int_col2);

--- a/tests/Driver/Pgsql/ActiveQueryFindTest.php
+++ b/tests/Driver/Pgsql/ActiveQueryFindTest.php
@@ -22,7 +22,7 @@ final class ActiveQueryFindTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryF
 
         /** asArray */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->where(['id' => 2])->asArray()->onePopulate();
+        $customer = $customerQuery->where(['id' => 2])->asArray()->one();
         $this->assertEquals([
             'id' => 2,
             'email' => 'user2@example.com',

--- a/tests/Driver/Pgsql/ActiveRecordTest.php
+++ b/tests/Driver/Pgsql/ActiveRecordTest.php
@@ -87,7 +87,7 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
 
         /** @var $model Type */
         $aqClass = new ActiveQuery(Type::class);
-        $query = $aqClass->onePopulate();
+        $query = $aqClass->one();
 
         $this->assertSame(123, $query->int_col);
         $this->assertSame(456, $query->int_col2);
@@ -171,8 +171,8 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
         $command->insertBatch('bool_values', [[true], [false]], ['bool_col'])->execute();
         $boolARQuery = new ActiveQuery(BoolAR::class);
 
-        $this->assertTrue($boolARQuery->where(['bool_col' => true])->onePopulate()->bool_col);
-        $this->assertFalse($boolARQuery->where(['bool_col' => false])->onePopulate()->bool_col);
+        $this->assertTrue($boolARQuery->where(['bool_col' => true])->one()->bool_col);
+        $this->assertFalse($boolARQuery->where(['bool_col' => false])->one()->bool_col);
 
         $this->assertEquals(1, $boolARQuery->where('bool_col = TRUE')->count('*'));
         $this->assertEquals(1, $boolARQuery->where('bool_col = FALSE')->count('*'));
@@ -368,7 +368,7 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
 
         $typeQuery = new ActiveQuery($type::class);
 
-        $type = $typeQuery->onePopulate();
+        $type = $typeQuery->one();
 
         foreach ($attributes as $attribute => $expected) {
             $expected = $expected[1] ?? $expected[0];

--- a/tests/Driver/Pgsql/MagicActiveRecordTest.php
+++ b/tests/Driver/Pgsql/MagicActiveRecordTest.php
@@ -102,8 +102,8 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
         $command->batchInsert('bool_values', ['bool_col'], [[true], [false]])->execute();
         $boolARQuery = new ActiveQuery(BoolAR::class);
 
-        $this->assertTrue($boolARQuery->where(['bool_col' => true])->onePopulate()->bool_col);
-        $this->assertFalse($boolARQuery->where(['bool_col' => false])->onePopulate()->bool_col);
+        $this->assertTrue($boolARQuery->where(['bool_col' => true])->one()->bool_col);
+        $this->assertFalse($boolARQuery->where(['bool_col' => false])->one()->bool_col);
 
         $this->assertEquals(1, $boolARQuery->where('bool_col = TRUE')->count('*'));
         $this->assertEquals(1, $boolARQuery->where('bool_col = FALSE')->count('*'));
@@ -299,7 +299,7 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
 
         $typeQuery = new ActiveQuery($type::class);
 
-        $type = $typeQuery->onePopulate();
+        $type = $typeQuery->one();
 
         foreach ($attributes as $attribute => $expected) {
             $expected = $expected[1] ?? $expected[0];

--- a/tests/MagicActiveRecordTest.php
+++ b/tests/MagicActiveRecordTest.php
@@ -196,7 +196,7 @@ abstract class MagicActiveRecordTest extends TestCase
 
         /** @var $model Type */
         $aqClass = new ActiveQuery(Type::class);
-        $query = $aqClass->onePopulate();
+        $query = $aqClass->one();
 
         $this->assertSame(123, $query->int_col);
         $this->assertSame(456, $query->int_col2);
@@ -218,10 +218,10 @@ abstract class MagicActiveRecordTest extends TestCase
 
         $animal = new ActiveQuery(Animal::class);
 
-        $animals = $animal->where(['type' => Dog::class])->onePopulate();
+        $animals = $animal->where(['type' => Dog::class])->one();
         $this->assertEquals('bark', $animals->getDoes());
 
-        $animals = $animal->where(['type' => Cat::class])->onePopulate();
+        $animals = $animal->where(['type' => Cat::class])->one();
         $this->assertEquals('meow', $animals->getDoes());
     }
 


### PR DESCRIPTION
Use `one()` and `all()` methods instead

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #286
