### PR TITLE
Prioritize `getXXX()` and `setXXX()` over magic properties

### DIFF
--- a/tests/MagicActiveRecordTest.php
+++ b/tests/MagicActiveRecordTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests;
 
+use DateTimeImmutable;
 use DivisionByZeroError;
 use ReflectionException;
 use Yiisoft\ActiveRecord\ActiveQuery;
@@ -881,5 +882,18 @@ abstract class MagicActiveRecordTest extends TestCase
             'orderItems2',
             'items2',
         ], $customer->relationNames());
+    }
+
+    public function testGetSetMethodsPriority(): void
+    {
+        $this->checkFixture($this->db(), 'order');
+
+        $datetime = DateTimeImmutable::createFromFormat('U', '1325502201');
+
+        $order = new Order();
+        $order->created_at = $datetime;
+
+        $this->assertSame(1_325_502_201, $order->get('created_at'));
+        $this->assertEquals($datetime, $order->getCreated_at());
     }
 }

--- a/tests/MagicActiveRecordTest.php
+++ b/tests/MagicActiveRecordTest.php
@@ -894,6 +894,6 @@ abstract class MagicActiveRecordTest extends TestCase
         $order->created_at = $datetime;
 
         $this->assertSame(1_325_502_201, $order->get('created_at'));
-        $this->assertEquals($datetime, $order->getCreated_at());
+        $this->assertEquals($datetime, $order->created_at);
     }
 }

--- a/tests/Stubs/MagicActiveRecord/Customer.php
+++ b/tests/Stubs/MagicActiveRecord/Customer.php
@@ -35,11 +35,6 @@ class Customer extends MagicActiveRecord
         return 'customer';
     }
 
-    public function getName(): string
-    {
-        return $this->get('name');
-    }
-
     public function getProfileQuery(): ActiveQuery
     {
         return $this->hasOne(Profile::class, ['id' => 'profile_id']);

--- a/tests/Stubs/MagicActiveRecord/Order.php
+++ b/tests/Stubs/MagicActiveRecord/Order.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
 
@@ -24,6 +26,18 @@ class Order extends MagicActiveRecord
     public function getTableName(): string
     {
         return self::TABLE_NAME;
+    }
+
+    public function getCreated_at(): DateTimeImmutable
+    {
+        return DateTimeImmutable::createFromFormat('U', (string) $this->get('created_at'));
+    }
+
+    public function setCreated_at(DateTimeInterface|int $createdAt): void
+    {
+        $this->set('created_at', $createdAt instanceof DateTimeInterface
+            ? $createdAt->getTimestamp()
+            : $createdAt);
     }
 
     public function setVirtualCustomerId(string|int|null $virtualCustomerId = null): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️
| Fixed issues  | #18