### PR TITLE
Add `ActiveQueryInterface::findByPk()`

### DIFF
--- a/docs/optimistic-locking.md
+++ b/docs/optimistic-locking.md
@@ -114,7 +114,7 @@ final class DocumentController
     ): ResponseInterface {
         $id = (int) $request->getAttribute('id');
 
-        $document = (new ActiveQuery(Document::class))->findOne($id);
+        $document = (new ActiveQuery(Document::class))->findByPk($id);
 
         if ($document === null) {
             throw new NotFoundException('Document not found.');
@@ -129,7 +129,7 @@ final class DocumentController
         $data = $request->getParsedBody();
         
         $id = (int) $data['id'];
-        $document = (new ActiveQuery(Document::class))->findOne($id);
+        $document = (new ActiveQuery(Document::class))->findByPk($id);
 
         if ($document === null) {
             throw new NotFoundException('Document not found.');

--- a/src/AbstractActiveRecord.php
+++ b/src/AbstractActiveRecord.php
@@ -554,7 +554,7 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
      */
     public function refresh(): bool
     {
-        $record = $this->query($this)->findOne($this->getPrimaryKey(true));
+        $record = $this->query($this)->findByPk($this->getPrimaryKey(true));
 
         return $this->refreshInternal($record);
     }

--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -818,7 +818,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         $primaryKey = $arInstance->primaryKey();
 
         if (empty($primaryKey)) {
-            throw new InvalidConfigException('"' . $arInstance::class . '" must have a primary key.');
+            throw new InvalidConfigException($arInstance::class . ' must have a primary key.');
         }
 
         if (count($primaryKey) !== count($values)) {

--- a/src/ActiveQueryInterface.php
+++ b/src/ActiveQueryInterface.php
@@ -11,6 +11,7 @@ use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidArgumentException;
 use Yiisoft\Db\Exception\InvalidConfigException;
 use Yiisoft\Db\Exception\NotSupportedException;
+use Yiisoft\Db\Expression\ExpressionInterface;
 use Yiisoft\Db\Query\QueryInterface;
 use Yiisoft\Definitions\Exception\CircularReferenceException;
 use Yiisoft\Definitions\Exception\NotInstantiableException;
@@ -378,223 +379,123 @@ interface ActiveQueryInterface extends QueryInterface
     public function relatedRecords(): ActiveRecordInterface|array|null;
 
     /**
-     * Finds ActiveRecord instance(s) by the given property values.
-     *
-     * If the property names are provided as array keys, the array will be treated as a set of column values.
-     *
-     * ```php
-     * $user = $query->find(['id' => 1])->one(); // WHERE id = 1
-     * ```
+     * This method is a shorthand for {@see ActiveQuery::setWhere()} and {@see ActiveQuery::one()}.
+     * Do not to pass user input to this method, use {@see findByPk()} instead.
      *
      * ```php
-     * $users = $query->find([
-     *     'name' => 'John',
-     *     'status' => 'active',
-     * ])->all(); // WHERE name = 'John' AND status = 'active'
-     * ```
+     * $customerQuery = new ActiveQuery(Customer::class);
      *
-     * Otherwise, the scalar value or array will be treated as a primary key value.
-     * In the examples below, the `id` column is the primary key of the table.
-     *
-     * ```php
-     * $user = $query->find(1)->one(); // WHERE id = 1
-     * ```
-     *
-     * ```php
-     * $user = $query->find([1])->one(); // WHERE id = 1
-     * ```
-     *
-     * For finding multiple records by primary key values use an array of arrays of primary key values.
-     *
-     * ```php
-     * $users = $query->find([[1, 2, 3]])->all(); // WHERE id IN (1, 2, 3)
-     * ```
-     *
-     * If the primary key is composite, the array may contain less or equal number of columns than the primary key.
-     * In case of fewer columns, the method will use the first primary key columns.
-     * In the examples below, the `id` and `id2` columns are the composite primary key of the table.
-     *
-     * ```php
-     * $orderItem = $query->find([1, 2])->one(); // WHERE id = 1 AND id2 = 2
-     * ```
-     *
-     * ```php
-     * $orderItems = $query->find(1)->all(); // WHERE id = 1
-     * ```
-     *
-     * ```php
-     * $orderItems = $query->find([[1, 2], 3])->all(); // WHERE id IN (1, 2) AND id2 = 3
-     * ```
-     */
-    public function find(array|float|int|string $properties): static;
-
-    /**
-     * Returns a single active record instance by a primary key or an array of column values.
-     *
-     * The method accepts:
-     *
-     *  - A scalar value (integer or string): query by a single primary key value and return the corresponding record
-     *    (or `null` if not found).
-     *  - A non-associative array: query by a list of primary key values and return the first record (or `null` if not
-     *    found).
-     *  - An associative array of name-value pairs: query by a set of property values and return a single record
-     *    matching all them (or `null` if not found).
-     *
-     * Note that `['id' => 1, 2]` is treated as a non-associative array.
-     *
-     * Column names are limited to current records' table columns for SQL DBMS, or filtered otherwise to be limited to
-     * simple filter conditions.
-     *
-     * That this method will automatically call the `one()` method and return an {@see ActiveRecordInterface} instance.
-     *
-     * Note: As this is a shorthand method only, using more complex conditions, `like ['!=', 'id', 1]` will not work.
-     * If you need to specify more complex conditions, in combination with {@see ActiveQuery::where()} instead.
-     *
-     * See the following code for usage examples:
-     *
-     * ```php
      * // find a single customer whose primary key value is 10
-     * $customerQuery = new ActiveQuery(Customer::class);
-     * $query = $customerQuery->findOne(10);
-     *
-     * // the above code is equal to:
-     * $customerQuery = new ActiveQuery(Customer::class);
-     * $query = $customerQuery->where(['id' => 10])->one();
-     *
-     * // find the customers whose primary key value is 10, 11 or 12.
-     * $customerQuery = new ActiveQuery(Customer::class);
-     * $query = $customerQuery->findOne([10, 11, 12]);
-     *
-     * // the above code is equal to:
-     * $customerQuery = new ActiveQuery(Customer::class);
-     * $query = $customerQuery->where(['id' => [10, 11, 12]])->one();
+     * $customer = $customerQuery->findOne(['id' => 10]);
+     * // the above code line is equal to:
+     * $customer = $customerQuery->setWhere(['id' => 10])->one();
      *
      * // find the first customer whose age is 30 and whose status is 1
-     * $customerQuery = new ActiveQuery(Customer::class);
-     * $query = $customerQuery->findOne(['age' => 30, 'status' => 1]);
-     *
-     * // the above code is equal to:
-     * $customerQuery = new ActiveQuery(Customer::class);
-     * $query = $customerQuery->where(['age' => 30, 'status' => 1])->one();
+     * $customer = $customerQuery->findOne(['age' => 30, 'status' => 1]);
+     * // the above code line is equal to:
+     * $customer = $customerQuery->setWhere(['age' => 30, 'status' => 1])->one();
      * ```
      *
-     * If you need to pass user input to this method, make sure the input value is scalar or in case of array condition,
-     * make sure the array structure can't be changed from the outside:
+     * Do NOT use the following code! It is possible to inject any condition to filter by arbitrary column values!
      *
      * ```php
-     * public function actionView(ServerRequestInterface $request)
-     * {
-     *     $id = (string) $request->getAttribute('id');
-     *
-     *     $aqClass = new ActiveQuery(Post::class);
-     *     $query = $aqClass->findOne($id);
-     * }
-     *
-     * - Explicitly specifying the column to search, passing a scalar or array here will always result in finding a
-     * single record:
-     *
-     * ```php
-     * $aqClass = new ActiveQuery(Post::class);
-     * $query = $aqClass->findOne(['id' => $id);
+     * $id = $request->getAttribute('id');
+     * $postQuery = new ActiveQuery(Post::class);
+     * $post = $postQuery->findOne($id); // Do NOT use this!
      * ```
      *
-     * Do NOT use the following code!, it is possible to inject an array condition to filter by arbitrary column values!:
+     * Explicitly specifying the column to search:
      *
      * ```php
-     * $aqClass = new ActiveQuery(Post::class);
-     * $query = $aqClass->findOne($id);
+     * $post = $postQuery->findOne(['id' => $id]);
+     * // or use {@see findByPk()} method
+     * $post = $postQuery->findByPk($id);
      * ```
      *
      * @throws InvalidConfigException
      *
      * @return ActiveRecordInterface|array|null Instance matching the condition, or `null` if nothing matches.
+     *
      */
-    public function findOne(array|float|int|string $properties): array|ActiveRecordInterface|null;
+    public function findOne(
+        array|string|ExpressionInterface|null $condition,
+        array $params = [],
+    ): array|ActiveRecordInterface|null;
 
     /**
-     * Returns a list of active record that matches the specified primary key value(s) or a set of column values.
-     *
-     * The method accepts:
-     *
-     *  - A scalar value (integer or string): query by a single primary key value and return an array containing the
-     *    corresponding record (or an empty array if not found).
-     *  - A non-associative array: query by a list of primary key values and return the corresponding records (or an
-     *    empty array if none found).
-     *    Note that an empty condition will result in an empty result as it will be interpreted as a search for
-     *    primary keys and not an empty `WHERE` condition.
-     *  - An associative array of name-value pairs: query by a set of property values and return an array of records
-     *    matching all them (or an empty array if none was found).
-     *
-     * Note that `['id' => 1, 2]` is treated as a non-associative array.
-     *
-     * Column names are limited to current records' table columns for SQL DBMS, or filtered otherwise to be limited
-     * to simple filter conditions.
-     *
-     * This method will automatically call the `all()` method and return an array of {@see ActiveRecordInterface}
-     * instances.
-     *
-     * Note: As this is a shorthand method only, using more complex conditions, `like ['!=', 'id', 1]` will not work.
-     * If you need to specify more complex conditions, in combination with {@see ActiveQuery::where()} instead.
-     *
-     * See the following code for usage examples:
+     * This method is a shorthand for {@see ActiveQuery::setWhere()} and {@see ActiveQuery::all()}.
+     * Do not to pass user input to this method, use {@see findByPk()} instead.
      *
      * ```php
-     * // find the customers whose primary key value is 10.
      * $customerQuery = new ActiveQuery(Customer::class);
-     * $customers = $customerQuery->findAll(10);
-     *
-     * // the above code is equal to.
-     * $customerQuery = new ActiveQuery(Customer::class);
-     * $customers = $customerQuery->where(['id' => 10])->all();
      *
      * // find the customers whose primary key value is 10, 11 or 12.
-     * $customerQuery = new ActiveQuery(Customer::class);
-     * $customers = $customerQuery->findAll([10, 11, 12]);
-     *
-     * // the above code is equal to,
-     * $customerQuery = new ActiveQuery(Customer::class);
-     * $customers = $customerQuery->where(['id' => [10, 11, 12]])->all();
+     * $customers = $customerQuery->findAll(['id' => [10, 11, 12]]);
+     * // the above code line is equal to:
+     * $customers = $customerQuery->setWhere(['id' => [10, 11, 12]])->all();
      *
      * // find customers whose age is 30 and whose status is 1.
-     * $customerQuery = new ActiveQuery(Customer::class);
      * $customers = $customerQuery->findAll(['age' => 30, 'status' => 1]);
-     *
-     * // the above code is equal to.
-     * $customerQuery = new ActiveQuery(Customer::class);
-     * $customers = $customerQuery->where(['age' => 30, 'status' => 1])->all();
+     * // the above code line is equal to.
+     * $customers = $customerQuery->setWhere(['age' => 30, 'status' => 1])->all();
      * ```
      *
-     * If you need to pass user input to this method, make sure the input value is scalar or in case of array condition,
-     * make sure the array structure can't be changed from the outside:
+     * Do NOT use the following code! It is possible to inject any condition to filter by arbitrary column values!
+     *
+     * ```php
+     * $id = $request->getAttribute('id');
+     * $postQuery = new ActiveQuery(Post::class);
+     * $posts = $postQuery->findAll($id); // Do NOT use this!
+     * ```
+     *
+     * Explicitly specifying the column to search:
+     *
+     * ```php
+     * $posts = $postQuery->findAll(['id' => $id]);
+     * // or use {@see findByPk()} method
+     * $post = $postQuery->findByPk($id);
+     * ```
+     *
+     * @return array An array of ActiveRecord instance, or an empty array if nothing matches.
+     */
+    public function findAll(array|string|ExpressionInterface|null $condition, array $params = []): array;
+
+    /**
+     * Finds an ActiveRecord instance by the given primary key value.
+     * In the examples below, the `id` column is the primary key of the table.
+     *
+     * ```php
+     * $customerQuery = new ActiveQuery(Customer::class);
+     *
+     * $customer = $customerQuery->findByPk(1); // WHERE id = 1
+     * ```
+     *
+     * ```php
+     * $customer = $customerQuery->findByPk([1]); // WHERE id = 1
+     * ```
+     *
+     * In the examples below, the `id` and `id2` columns are the composite primary key of the table.
+     *
+     * ```php
+     * $orderItemQuery = new ActiveQuery(OrderItem::class);
+     *
+     * $orderItem = $orderItemQuery->findByPk([1, 2]); // WHERE id = 1 AND id2 = 2
+     * ```
+     *
+     * If you need to pass user input to this method, make sure the input value is scalar or in case of array, make sure
+     * the array values are scalar:
      *
      * ```php
      * public function actionView(ServerRequestInterface $request)
      * {
      *     $id = (string) $request->getAttribute('id');
      *
-     *     $aqClass = new ActiveQuery(Post::class);
-     *     $query = $aqClass->findOne($id);
+     *     $customerQuery = new ActiveQuery(Customer::class);
+     *     $customer = $customerQuery->findByPk($id);
      * }
      * ```
-     *
-     * Explicitly specifying the column to search, passing a scalar or array here will always result in finding a single
-     * record:
-     *
-     * ```php
-     * $aqClass = new ActiveQuery(Post::class);
-     * $aqCLass = $aqClass->findOne(['id' => $id]);
-     * ```
-     *
-     * Do NOT use the following code! It's possible to inject an array condition to filter by arbitrary column values!:
-     *
-     * ```php
-     * $aqClass = new ActiveQuery(Post::class);
-     * $aqClass = $aqClass->findOne($id);
-     * ```
-     *
-     * @return array An array of ActiveRecord instance, or an empty array if nothing matches.
      */
-    public function findAll(array|float|int|string $properties): array;
+    public function findByPk(array|float|int|string $values): array|ActiveRecordInterface|null;
 
     /**
      * Returns a value indicating whether the query result rows should be returned as arrays instead of Active Record

--- a/src/ActiveQueryInterface.php
+++ b/src/ActiveQueryInterface.php
@@ -415,7 +415,6 @@ interface ActiveQueryInterface extends QueryInterface
      * @throws InvalidConfigException
      *
      * @return ActiveRecordInterface|array|null Instance matching the condition, or `null` if nothing matches.
-     *
      */
     public function findOne(
         array|string|ExpressionInterface|null $condition,

--- a/src/ActiveQueryInterface.php
+++ b/src/ActiveQueryInterface.php
@@ -396,7 +396,8 @@ interface ActiveQueryInterface extends QueryInterface
      * $customer = $customerQuery->setWhere(['age' => 30, 'status' => 1])->one();
      * ```
      *
-     * Do NOT use the following code! It is possible to inject any condition to filter by arbitrary column values!
+     * > [!WARNING]
+     * > Do NOT use the following code! It is possible to inject any condition to filter by arbitrary column values!
      *
      * ```php
      * $id = $request->getAttribute('id');
@@ -439,7 +440,8 @@ interface ActiveQueryInterface extends QueryInterface
      * $customers = $customerQuery->setWhere(['age' => 30, 'status' => 1])->all();
      * ```
      *
-     * Do NOT use the following code! It is possible to inject any condition to filter by arbitrary column values!
+     * > [!WARNING]
+     * > Do NOT use the following code! It is possible to inject any condition to filter by arbitrary column values!
      *
      * ```php
      * $id = $request->getAttribute('id');

--- a/src/Trait/RepositoryTrait.php
+++ b/src/Trait/RepositoryTrait.php
@@ -6,6 +6,7 @@ namespace Yiisoft\ActiveRecord\Trait;
 
 use Yiisoft\ActiveRecord\ActiveQueryInterface;
 use Yiisoft\ActiveRecord\ActiveRecordInterface;
+use Yiisoft\Db\Expression\ExpressionInterface;
 
 /**
  * Trait to support static methods {@see find()}, {@see findOne()}, {@see findAll()}, {@see findBySql()} to find records.
@@ -37,17 +38,18 @@ use Yiisoft\ActiveRecord\ActiveRecordInterface;
 trait RepositoryTrait
 {
     /**
-     * Shortcut for {@see ActiveQueryInterface::find()} method.
+     * Returns an instance of {@see ActiveQueryInterface} instantiated by {@see ActiveRecordInterface::query()} method.
+     * If the `$condition` parameter is not null, it calls {@see ActiveQueryInterface::andWhere()} method.
      */
-    public static function find(array|float|int|string $properties = []): ActiveQueryInterface
+    public static function find(array|string|ExpressionInterface|null $condition = null, array $params = []): ActiveQueryInterface
     {
         $query = static::instantiate()->query();
 
-        if ($properties === []) {
+        if ($condition === null) {
             return $query;
         }
 
-        return $query->find($properties);
+        return $query->andWhere($condition, $params);
     }
 
     /**
@@ -55,9 +57,17 @@ trait RepositoryTrait
      *
      * @return (ActiveRecordInterface|array)[]
      */
-    public static function findAll(array|float|int|string $properties = []): array
+    public static function findAll(array|string|ExpressionInterface|null $condition = null, array $params = []): array
     {
-        return static::find($properties)->all();
+        return static::find($condition, $params)->all();
+    }
+
+    /**
+     * Shortcut for {@see ActiveQueryInterface::findByPk()} method.
+     */
+    public static function findByPk(array|float|int|string $values): array|ActiveRecordInterface|null
+    {
+        return static::instantiate()->query()->findByPk($values);
     }
 
     /**
@@ -71,9 +81,11 @@ trait RepositoryTrait
     /**
      * Shortcut for {@see find()} method with calling {@see ActiveQueryInterface::one()} method to get one record.
      */
-    public static function findOne(array|float|int|string $properties = []): ActiveRecordInterface|array|null
-    {
-        return static::find($properties)->one();
+    public static function findOne(
+        array|string|ExpressionInterface|null $condition = null,
+        array $params = [],
+    ): ActiveRecordInterface|array|null {
+        return static::find($condition, $params)->one();
     }
 
     protected static function instantiate(): ActiveRecordInterface

--- a/tests/ActiveQueryFindTest.php
+++ b/tests/ActiveQueryFindTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests;
 
-use TypeError;
 use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\ActiveQueryInterface;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Customer;

--- a/tests/ActiveQueryFindTest.php
+++ b/tests/ActiveQueryFindTest.php
@@ -11,7 +11,9 @@ use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Customer;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\CustomerQuery;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Order;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\OrderItem;
+use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Type;
 use Yiisoft\Db\Exception\InvalidArgumentException;
+use Yiisoft\Db\Exception\InvalidConfigException;
 
 use function ksort;
 
@@ -742,5 +744,31 @@ abstract class ActiveQueryFindTest extends TestCase
         $this->expectExceptionMessage('The primary key has 2 columns, but 1 values are passed.');
 
         $query->findByPk(1);
+    }
+
+    public function testFindByPkWithoutPk(): void
+    {
+        $this->checkFixture($this->db(), 'type');
+
+        $query = new ActiveQuery(Type::class);
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage('Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Type must have a primary key.');
+
+        $query->findByPk(1);
+    }
+
+    public function testFindByPkWithJoin(): void
+    {
+        $this->checkFixture($this->db(), 'order');
+
+        $query = new ActiveQuery(Order::class);
+
+        $query->joinWith('items');
+
+        $order = $query->findByPk(1);
+
+        $this->assertInstanceOf(Order::class, $order);
+        $this->assertEquals(1, $order->getId());
     }
 }

--- a/tests/ActiveQueryFindTest.php
+++ b/tests/ActiveQueryFindTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests;
 
+use TypeError;
 use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\ActiveQueryInterface;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Customer;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\CustomerQuery;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Order;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\OrderItem;
+use Yiisoft\Db\Exception\InvalidArgumentException;
 
 use function ksort;
 
@@ -20,9 +22,13 @@ abstract class ActiveQueryFindTest extends TestCase
         $this->checkFixture($this->db(), 'customer', true);
 
         $customerQuery = new ActiveQuery(Customer::class);
-        $this->assertCount(1, $customerQuery->findAll(3));
         $this->assertCount(1, $customerQuery->findAll(['id' => 1]));
         $this->assertCount(3, $customerQuery->findAll(['id' => [1, 2, 3]]));
+
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage('Yiisoft\ActiveRecord\ActiveQuery::findAll(): Argument #1 ($condition) must be of type Yiisoft\Db\Expression\ExpressionInterface|array|string|null, int given');
+
+        $customerQuery->findAll(3);
     }
 
     public function testFindScalar(): void
@@ -96,7 +102,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
         $orderQuery = new ActiveQuery(Order::class);
 
-        $orders = $orderQuery->findOne(2);
+        $orders = $orderQuery->findByPk(2);
         $this->assertCount(0, $orders->getBooks());
         $this->assertEquals(2, $orders->get('id'));
 
@@ -152,7 +158,7 @@ abstract class ActiveQueryFindTest extends TestCase
         $orderItemQuery = new ActiveQuery(OrderItem::class);
 
         /** @var $orderItems OrderItem */
-        $orderItems = $orderItemQuery->findOne([1, 1]);
+        $orderItems = $orderItemQuery->findByPk([1, 1]);
 
         $orderItemNoJoin = $orderItems->getOrderItemCompositeNoJoin();
         $this->assertInstanceOf(OrderItem::class, $orderItemNoJoin);
@@ -167,7 +173,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
         $orderQuery = new ActiveQuery(Order::class);
 
-        $orders = $orderQuery->findOne(1);
+        $orders = $orderQuery->findByPk(1);
         $customerNoJoin = $orders->getCustomer();
         $this->assertInstanceOf(Customer::class, $customerNoJoin);
 
@@ -219,11 +225,11 @@ abstract class ActiveQueryFindTest extends TestCase
 
         /** find by a single primary key */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->findOne(2);
+        $customer = $customerQuery->findByPk(2);
         $this->assertInstanceOf(Customer::class, $customer);
         $this->assertEquals('user2', $customer->getName());
 
-        $customer = $customerQuery->findOne(5);
+        $customer = $customerQuery->findByPk(5);
         $this->assertNull($customer);
 
         $customerQuery = new ActiveQuery(Customer::class);
@@ -481,7 +487,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
         $customerQuery = new ActiveQuery(Customer::class);
 
-        $customer = $customerQuery->findOne(2);
+        $customer = $customerQuery->findByPk(2);
         $customer->setName(null);
         $customer->save();
 
@@ -686,7 +692,7 @@ abstract class ActiveQueryFindTest extends TestCase
         $this->checkFixture($this->db(), 'customer');
 
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->findOne(2);
+        $customer = $customerQuery->findByPk(2);
         $this->assertFalse($customer->isRelationPopulated('orders'));
 
         $orders = $customer->getOrders();
@@ -697,7 +703,7 @@ abstract class ActiveQueryFindTest extends TestCase
         $customer->resetRelation('orders');
         $this->assertFalse($customer->isRelationPopulated('orders'));
 
-        $customer = $customerQuery->findOne(2);
+        $customer = $customerQuery->findByPk(2);
         $this->assertFalse($customer->isRelationPopulated('orders'));
 
         $orders = $customer->getOrdersQuery()->where(['id' => 3])->all();
@@ -712,11 +718,29 @@ abstract class ActiveQueryFindTest extends TestCase
         $this->checkFixture($this->db(), 'order');
 
         $orderQuery = new ActiveQuery(Order::class);
-        $order = $orderQuery->findOne(1);
+        $order = $orderQuery->findByPk(1);
 
         $this->assertEquals(1, $order->getId());
         $this->assertCount(2, $order->getItems());
         $this->assertEquals(1, $order->getItems()[0]->getId());
         $this->assertEquals(2, $order->getItems()[1]->getId());
+    }
+
+    public function testFindByPkComposite(): void
+    {
+        $this->checkFixture($this->db(), 'order_item');
+
+        $query = new ActiveQuery(OrderItem::class);
+
+        $orderItem = $query->findByPk([1, 1]);
+
+        $this->assertInstanceOf(OrderItem::class, $orderItem);
+        $this->assertEquals(1, $orderItem->getOrderId());
+        $this->assertEquals(1, $orderItem->getItemId());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The primary key has 2 columns, but 1 values are passed.');
+
+        $query->findByPk(1);
     }
 }

--- a/tests/ActiveQueryFindTest.php
+++ b/tests/ActiveQueryFindTest.php
@@ -26,11 +26,6 @@ abstract class ActiveQueryFindTest extends TestCase
         $customerQuery = new ActiveQuery(Customer::class);
         $this->assertCount(1, $customerQuery->findAll(['id' => 1]));
         $this->assertCount(3, $customerQuery->findAll(['id' => [1, 2, 3]]));
-
-        $this->expectException(TypeError::class);
-        $this->expectExceptionMessage('Yiisoft\ActiveRecord\ActiveQuery::findAll(): Argument #1 ($condition) must be of type Yiisoft\Db\Expression\ExpressionInterface|array|string|null, int given');
-
-        $customerQuery->findAll(3);
     }
 
     public function testFindScalar(): void

--- a/tests/ActiveQueryTest.php
+++ b/tests/ActiveQueryTest.php
@@ -423,7 +423,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $customerQuery = new ActiveQuery(Customer::class);
 
-        $customers = $customerQuery->findOne(1);
+        $customers = $customerQuery->findByPk(1);
 
         $items = $customers->getOrderItems();
 
@@ -633,15 +633,15 @@ abstract class ActiveQueryTest extends TestCase
 
         /** lazy loading with ON condition */
         $orderQuery = new ActiveQuery(Order::class);
-        $order = $orderQuery->findOne(1);
+        $order = $orderQuery->findByPk(1);
         $this->assertCount(2, $order->getBooks2());
 
         $orderQuery = new ActiveQuery(Order::class);
-        $order = $orderQuery->findOne(2);
+        $order = $orderQuery->findByPk(2);
         $this->assertCount(0, $order->getBooks2());
 
         $order = new ActiveQuery(Order::class);
-        $order = $order->findOne(3);
+        $order = $order->findByPk(3);
         $this->assertCount(1, $order->getBooks2());
 
         /** eager loading with ON condition */
@@ -669,7 +669,7 @@ abstract class ActiveQueryTest extends TestCase
 
         /** {@see https://github.com/yiisoft/yii2/issues/2880} */
         $orderQuery = new ActiveQuery(Order::class);
-        $query = $orderQuery->findOne(1);
+        $query = $orderQuery->findByPk(1);
         $customer = $query->getCustomerQuery()->joinWith(
             [
                 'orders' => static function ($q) {
@@ -986,7 +986,7 @@ abstract class ActiveQueryTest extends TestCase
 
         /** relational query */
         $orderQuery = new ActiveQuery(Order::class);
-        $order = $orderQuery->findOne(1);
+        $order = $orderQuery->findByPk(1);
 
         $customerQuery = $order->getCustomerQuery()->innerJoinWith(['orders o'], false);
 
@@ -1397,7 +1397,7 @@ abstract class ActiveQueryTest extends TestCase
 
         /** lazy loading */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->findOne(2);
+        $customer = $customerQuery->findByPk(2);
         $orders = $customer->getOrders2();
         $this->assertCount(2, $orders);
         $this->assertSame($customer->getOrders2()[0]->getCustomer2(), $customer);
@@ -1405,7 +1405,7 @@ abstract class ActiveQueryTest extends TestCase
 
         /** ad-hoc lazy loading */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->findOne(2);
+        $customer = $customerQuery->findByPk(2);
         $orders = $customer->getOrders2Query()->all();
         $this->assertCount(2, $orders);
         $this->assertSame($orders[0]->getCustomer2(), $customer);
@@ -1469,7 +1469,7 @@ abstract class ActiveQueryTest extends TestCase
 
         /** via table with delete. */
         $orderQuery = new ActiveQuery(Order::class);
-        $order = $orderQuery->findOne(1);
+        $order = $orderQuery->findByPk(1);
         $this->assertCount(2, $order->getBooksViaTable());
 
         $orderItemQuery = new ActiveQuery(OrderItem::class);
@@ -1507,7 +1507,7 @@ abstract class ActiveQueryTest extends TestCase
 
         /** {@see https://github.com/yiisoft/yii2/issues/4938} */
         $categoryQuery = new ActiveQuery(Category::class);
-        $category = $categoryQuery->findOne(2);
+        $category = $categoryQuery->findByPk(2);
         $this->assertInstanceOf(Category::class, $category);
         $this->assertEquals(3, $category->getItemsQuery()->count());
         $this->assertEquals(1, $category->getLimitedItemsQuery()->count());
@@ -1838,7 +1838,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertSame($orderItemTableName, $orderItem->getTableName());
 
         $orderQuery = new ActiveQuery(Order::class);
-        $order = $orderQuery->findOne(1);
+        $order = $orderQuery->findByPk(1);
         $itemsSQL = $order->getOrderItemsQuery()->createCommand()->getRawSql();
         $expectedSQL = DbHelper::replaceQuotes(
             <<<SQL
@@ -1848,7 +1848,7 @@ abstract class ActiveQueryTest extends TestCase
         );
         $this->assertEquals($expectedSQL, $itemsSQL);
 
-        $order = $orderQuery->findOne(1);
+        $order = $orderQuery->findByPk(1);
         $itemsSQL = $order->getOrderItemsQuery()->joinWith('item')->createCommand()->getRawSql();
         $expectedSQL = DbHelper::replaceQuotes(
             <<<SQL
@@ -1864,7 +1864,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->checkFixture($this->db(), 'order_item', true);
 
         $orderItemQuery = new ActiveQuery(OrderItem::class);
-        $orderItems = $orderItemQuery->findOne(1);
+        $orderItems = $orderItemQuery->findByPk([1, 1]);
         $this->assertEquals(1, $orderItems->getOrder()->getId());
         $this->assertEquals(1, $orderItems->getItem()->getId());
 
@@ -1917,7 +1917,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $orderQuery = new ActiveQuery(Order::class);
 
-        $orders = $orderQuery->findOne(1);
+        $orders = $orderQuery->findByPk(1);
         $orderItemIds = ArArrayHelper::getColumn($orders->getItems(), 'id');
         sort($orderItemIds);
         $this->assertSame([1, 2], $orderItemIds);
@@ -1944,7 +1944,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $customerQuery = new ActiveQuery(Customer::class);
 
-        $customer = $customerQuery->findOne(1);
+        $customer = $customerQuery->findByPk(1);
 
         /** request the inverseOf relation without explicitly (eagerly) loading it */
         $orders2 = $customer->getOrders2Query()->all();
@@ -1976,13 +1976,13 @@ abstract class ActiveQueryTest extends TestCase
         $this->checkFixture($this->db(), 'document');
 
         $documentQuery = new ActiveQuery(Document::class);
-        $record = $documentQuery->findOne(1);
+        $record = $documentQuery->findByPk(1);
 
         $record->content = 'New Content';
         $record->save();
         $this->assertEquals(1, $record->version);
 
-        $record = $documentQuery->findOne(1);
+        $record = $documentQuery->findByPk(1);
 
         $record->content = 'Rewrite attempt content';
         $record->version = 0;
@@ -1995,7 +1995,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->checkFixture($this->db(), 'document', true);
 
         $documentQuery = new ActiveQuery(Document::class);
-        $document = $documentQuery->findOne(1);
+        $document = $documentQuery->findByPk(1);
 
         $this->assertSame(0, $document->version);
 
@@ -2010,7 +2010,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->checkFixture($this->db(), 'document', true);
 
         $documentQuery = new ActiveQuery(Document::class);
-        $document = $documentQuery->findOne(1);
+        $document = $documentQuery->findByPk(1);
 
         $this->assertSame(0, $document->version);
         $this->assertSame(1, $document->delete());
@@ -2026,11 +2026,11 @@ abstract class ActiveQueryTest extends TestCase
         $this->checkFixture($this->db(), 'bit_values');
 
         $bitValueQuery = new ActiveQuery(BitValues::class);
-        $falseBit = $bitValueQuery->findOne(1);
+        $falseBit = $bitValueQuery->findByPk(1);
         $this->assertFalse($falseBit->val);
 
         $bitValueQuery = new ActiveQuery(BitValues::class);
-        $trueBit = $bitValueQuery->findOne(2);
+        $trueBit = $bitValueQuery->findByPk(2);
         $this->assertTrue($trueBit->val);
     }
 
@@ -2039,12 +2039,12 @@ abstract class ActiveQueryTest extends TestCase
         $this->checkFixture($this->db(), 'order');
 
         $orderQuery = new ActiveQuery(Order::class);
-        $order = $orderQuery->findOne(1);
+        $order = $orderQuery->findByPk(1);
         $newTotal = 978;
         $this->assertSame(1, $order->updateProperties(['total' => $newTotal]));
         $this->assertEquals($newTotal, $order->getTotal());
 
-        $order = $orderQuery->findOne(1);
+        $order = $orderQuery->findByPk(1);
         $this->assertEquals($newTotal, $order->getTotal());
 
         /** @see https://github.com/yiisoft/yii2/issues/12143 */
@@ -2070,7 +2070,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $customerQuery->joinWithProfile = true;
 
-        $arClass = $customerQuery->findOne(1);
+        $arClass = $customerQuery->findByPk(1);
 
         $this->assertTrue($arClass->refresh());
 
@@ -2083,7 +2083,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $orderItem = new ActiveQuery(OrderItem::class);
 
-        $orderItem = $orderItem->findOne(1);
+        $orderItem = $orderItem->findByPk([1, 1]);
 
         $this->assertInstanceOf(Order::class, $orderItem->getCustom());
     }
@@ -2104,7 +2104,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $customer = new ActiveQuery(Customer::class);
 
-        $values = $customer->findOne(1)->propertyValues();
+        $values = $customer->findByPk(1)->propertyValues();
 
         $this->assertEquals($expectedValues, $values);
     }
@@ -2115,7 +2115,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $customer = new ActiveQuery(Customer::class);
 
-        $values = $customer->findOne(1)->propertyValues(['id', 'email', 'name']);
+        $values = $customer->findByPk(1)->propertyValues(['id', 'email', 'name']);
 
         $this->assertEquals(['id' => 1, 'email' => 'user1@example.com', 'name' => 'user1'], $values);
     }
@@ -2126,7 +2126,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $customer = new ActiveQuery(Customer::class);
 
-        $values = $customer->findOne(1)->propertyValues(null, ['status', 'bool_status', 'profile_id']);
+        $values = $customer->findByPk(1)->propertyValues(null, ['status', 'bool_status', 'profile_id']);
 
         $this->assertEquals(
             ['id' => 1, 'email' => 'user1@example.com', 'name' => 'user1', 'address' => 'address1'],
@@ -2140,7 +2140,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $customer = new ActiveQuery(Customer::class);
 
-        $query = $customer->findOne(1);
+        $query = $customer->findByPk(1);
         $this->assertEquals('user1', $query->oldValue('name'));
         $this->assertEquals($query->propertyValues(), $query->oldValues());
 
@@ -2166,7 +2166,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $customer = new ActiveQuery(Customer::class);
 
-        $query = $customer->findOne(1);
+        $query = $customer->findByPk(1);
         $this->assertEquals($expectedValues, $query->propertyValues());
         $this->assertEquals($query->propertyValues(), $query->oldValues());
 
@@ -2186,7 +2186,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $query = new ActiveQuery(Customer::class);
 
-        $customer = $query->findOne(1);
+        $customer = $query->findByPk(1);
         $this->assertTrue($customer->get('bool_status'));
         $this->assertTrue($customer->oldValue('bool_status'));
 
@@ -2232,7 +2232,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $customer = new ActiveQuery(Customer::class);
 
-        $query = $customer->findOne(1);
+        $query = $customer->findByPk(1);
 
         $this->expectException(UnknownPropertyException::class);
         $this->expectExceptionMessage('Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Customer::noExist');
@@ -2247,7 +2247,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $customer = new ActiveQuery(Customer::class);
 
-        $query = $customer->findOne(2);
+        $query = $customer->findByPk(2);
 
         $this->expectException(InvalidCallException::class);
         $this->expectExceptionMessage(
@@ -2262,7 +2262,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $customer = new ActiveQuery(Customer::class);
 
-        $query = $customer->findOne(1);
+        $query = $customer->findByPk(1);
 
         /** Throwing exception */
         $this->expectException(InvalidArgumentException::class);
@@ -2280,7 +2280,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $customer = new ActiveQuery(Customer::class);
 
-        $query = $customer->findOne(1);
+        $query = $customer->findByPk(1);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -2298,7 +2298,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $customer = new ActiveQuery(Customer::class);
 
-        $query = $customer->findOne(1);
+        $query = $customer->findByPk(1);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -2329,30 +2329,30 @@ abstract class ActiveQueryTest extends TestCase
 
         /** has many without delete */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->findOne(2);
+        $customer = $customerQuery->findByPk(2);
         $this->assertCount(2, $customer->getOrdersWithNullFK());
         $customer->unlink('ordersWithNullFK', $customer->getOrdersWithNullFK()[1], false);
         $this->assertCount(1, $customer->getOrdersWithNullFK());
 
         $orderWithNullFKQuery = new ActiveQuery(OrderWithNullFK::class);
-        $orderWithNullFK = $orderWithNullFKQuery->findOne(3);
+        $orderWithNullFK = $orderWithNullFKQuery->findByPk(3);
         $this->assertEquals(3, $orderWithNullFK->getId());
         $this->assertNull($orderWithNullFK->getCustomerId());
 
         /** has many with delete */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->findOne(2);
+        $customer = $customerQuery->findByPk(2);
         $this->assertCount(2, $customer->getOrders());
 
         $customer->unlink('orders', $customer->getOrders()[1], true);
         $this->assertCount(1, $customer->getOrders());
 
         $orderQuery = new ActiveQuery(Order::class);
-        $this->assertNull($orderQuery->findOne(3));
+        $this->assertNull($orderQuery->findByPk(3));
 
         /** via model with delete */
         $orderQuery = new ActiveQuery(Order::class);
-        $order = $orderQuery->findOne(2);
+        $order = $orderQuery->findByPk(2);
         $this->assertCount(3, $order->getItems());
         $this->assertCount(3, $order->getOrderItems());
         $order->unlink('items', $order->getItems()[2], true);
@@ -2376,7 +2376,7 @@ abstract class ActiveQueryTest extends TestCase
         $orderWithNullFKInstance->updateAll(['customer_id' => 1]);
 
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->findOne(1);
+        $customer = $customerQuery->findByPk(1);
         $this->assertCount(3, $customer->getOrdersWithNullFK());
         $this->assertCount(1, $customer->getExpensiveOrdersWithNullFK());
 
@@ -2388,7 +2388,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertCount(0, $customer->getExpensiveOrdersWithNullFK());
         $this->assertEquals(3, $orderWithNullFKQuery->count());
 
-        $customer = $customerQuery->findOne(1);
+        $customer = $customerQuery->findByPk(1);
         $this->assertCount(2, $customer->getOrdersWithNullFK());
         $this->assertCount(0, $customer->getExpensiveOrdersWithNullFK());
     }
@@ -2402,7 +2402,7 @@ abstract class ActiveQueryTest extends TestCase
         $orderInstance->updateAll(['customer_id' => 1]);
 
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->findOne(1);
+        $customer = $customerQuery->findByPk(1);
         $this->assertCount(3, $customer->getOrders());
         $this->assertCount(1, $customer->getExpensiveOrders());
 
@@ -2414,7 +2414,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertCount(0, $customer->getExpensiveOrders());
         $this->assertEquals(2, $orderQuery->count());
 
-        $customer = $customerQuery->findOne(1);
+        $customer = $customerQuery->findByPk(1);
         $this->assertCount(2, $customer->getOrders());
         $this->assertCount(0, $customer->getExpensiveOrders());
     }
@@ -2424,7 +2424,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->checkFixture($this->db(), 'customer');
 
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->findOne(2);
+        $customer = $customerQuery->findByPk(2);
         $this->assertInstanceOf(Customer::class, $customer);
         $this->assertEquals('user2', $customer->get('name'));
         $this->assertFalse($customer->getIsNewRecord());
@@ -2435,25 +2435,25 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertEquals('user2x', $customer->get('name'));
         $this->assertFalse($customer->getIsNewRecord());
 
-        $customer2 = $customerQuery->findOne(2);
+        $customer2 = $customerQuery->findByPk(2);
         $this->assertEquals('user2x', $customer2->get('name'));
 
         /** no update */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->findOne(1);
+        $customer = $customerQuery->findByPk(1);
 
         $customer->set('name', 'user1');
         $this->assertEquals(0, $customer->update());
 
         /** updateAll */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->findOne(3);
+        $customer = $customerQuery->findByPk(3);
         $this->assertEquals('user3', $customer->get('name'));
 
         $ret = $customer->updateAll(['name' => 'temp'], ['id' => 3]);
         $this->assertEquals(1, $ret);
 
-        $customer = $customerQuery->findOne(3);
+        $customer = $customerQuery->findByPk(3);
         $this->assertEquals('temp', $customer->get('name'));
 
         $ret = $customer->updateAll(['name' => 'tempX']);
@@ -2501,13 +2501,13 @@ abstract class ActiveQueryTest extends TestCase
 
         /** delete */
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->findOne(2);
+        $customer = $customerQuery->findByPk(2);
         $this->assertInstanceOf(Customer::class, $customer);
         $this->assertEquals('user2', $customer->getName());
 
         $customer->delete();
 
-        $customer = $customerQuery->findOne(2);
+        $customer = $customerQuery->findByPk(2);
         $this->assertNull($customer);
 
         /** deleteAll */
@@ -2535,7 +2535,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $orderQuery = new ActiveQuery(Order::class);
 
-        $order = $orderQuery->findOne(2);
+        $order = $orderQuery->findByPk(2);
 
         $expensiveItems = $order->getExpensiveItemsUsingViaWithCallable();
         $cheapItems = $order->getCheapItemsUsingViaWithCallable();
@@ -2552,7 +2552,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->checkFixture($this->db(), 'customer', true);
 
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->findOne(2);
+        $customer = $customerQuery->findByPk(2);
         $this->assertCount(2, $customer->getOrders());
 
         /** has many */
@@ -2570,7 +2570,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertTrue($order->getIsNewRecord());
 
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->findOne(1);
+        $customer = $customerQuery->findByPk(1);
         $this->assertNull($order->getCustomer());
 
         $order->link('customer', $customer);
@@ -2580,7 +2580,7 @@ abstract class ActiveQueryTest extends TestCase
 
         /** via model */
         $orderQuery = new ActiveQuery(Order::class);
-        $order = $orderQuery->findOne(1);
+        $order = $orderQuery->findByPk(1);
         $this->assertCount(2, $order->getItems());
         $this->assertCount(2, $order->getOrderItems());
 
@@ -2589,7 +2589,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertNull($orderItem);
 
         $itemQuery = new ActiveQuery(Item::class);
-        $item = $itemQuery->findOne(3);
+        $item = $itemQuery->findByPk(3);
         $order->link('items', $item, ['quantity' => 10, 'subtotal' => 100]);
         $this->assertCount(3, $order->getItems());
         $this->assertCount(3, $order->getOrderItems());
@@ -2605,15 +2605,15 @@ abstract class ActiveQueryTest extends TestCase
     {
         $this->checkFixture($this->db(), 'customer');
 
-        $customerA = (new ActiveQuery(Customer::class))->findOne(1);
-        $customerB = (new ActiveQuery(Customer::class))->findOne(2);
+        $customerA = (new ActiveQuery(Customer::class))->findByPk(1);
+        $customerB = (new ActiveQuery(Customer::class))->findByPk(2);
         $this->assertFalse($customerA->equals($customerB));
 
-        $customerB = (new ActiveQuery(Customer::class))->findOne(1);
+        $customerB = (new ActiveQuery(Customer::class))->findByPk(1);
         $this->assertTrue($customerA->equals($customerB));
 
-        $customerA = (new ActiveQuery(Customer::class))->findOne(1);
-        $customerB = (new ActiveQuery(Item::class))->findOne(1);
+        $customerA = (new ActiveQuery(Customer::class))->findByPk(1);
+        $customerB = (new ActiveQuery(Item::class))->findByPk(1);
         $this->assertFalse($customerA->equals($customerB));
     }
 

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -6,7 +6,6 @@ namespace Yiisoft\ActiveRecord\Tests;
 
 use ArgumentCountError;
 use DivisionByZeroError;
-use ReflectionException;
 use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\ArArrayHelper;
 use Yiisoft\ActiveRecord\ConnectionProvider;

--- a/tests/ArrayableTraitTest.php
+++ b/tests/ArrayableTraitTest.php
@@ -40,7 +40,7 @@ abstract class ArrayableTraitTest extends TestCase
         $this->checkFixture($this->db(), 'customer', true);
 
         $customerQuery = new ActiveQuery(Customer::class);
-        $customer = $customerQuery->findOne(1);
+        $customer = $customerQuery->findByPk(1);
 
         $this->assertSame(
             [
@@ -61,7 +61,7 @@ abstract class ArrayableTraitTest extends TestCase
         $this->checkFixture($this->db(), 'customer', true);
 
         $customerQuery = new ActiveQuery(CustomerClosureField::class);
-        $customer = $customerQuery->findOne(1);
+        $customer = $customerQuery->findByPk(1);
 
         $this->assertSame(
             [
@@ -84,11 +84,11 @@ abstract class ArrayableTraitTest extends TestCase
         $customerQuery = new ActiveQuery(CustomerForArrayable::class);
 
         /** @var CustomerForArrayable $customer */
-        $customer = $customerQuery->findOne(1);
+        $customer = $customerQuery->findByPk(1);
         /** @var CustomerForArrayable $customer2 */
-        $customer2 = $customerQuery->findOne(2);
+        $customer2 = $customerQuery->findByPk(2);
         /** @var CustomerForArrayable $customer3 */
-        $customer3 = $customerQuery->findOne(3);
+        $customer3 = $customerQuery->findByPk(3);
 
         $customer->setItem($customer2);
         $customer->setItems($customer3);

--- a/tests/Driver/Mssql/ActiveRecordTest.php
+++ b/tests/Driver/Mssql/ActiveRecordTest.php
@@ -58,6 +58,6 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
 
         $testRecordQuery = new ActiveQuery(TestTriggerAlert::class);
 
-        $this->assertEquals('test', $testRecordQuery->findOne(1)->stringcol);
+        $this->assertEquals('test', $testRecordQuery->findByPk(1)->stringcol);
     }
 }

--- a/tests/Driver/Mssql/MagicActiveRecordTest.php
+++ b/tests/Driver/Mssql/MagicActiveRecordTest.php
@@ -52,6 +52,6 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
 
         $testRecordQuery = new ActiveQuery(TestTriggerAlert::class);
 
-        $this->assertEquals('test', $testRecordQuery->findOne(1)->stringcol);
+        $this->assertEquals('test', $testRecordQuery->findByPk(1)->stringcol);
     }
 }

--- a/tests/Driver/Oracle/ActiveQueryTest.php
+++ b/tests/Driver/Oracle/ActiveQueryTest.php
@@ -222,7 +222,7 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
 
         /** relational query */
         $orderQuery = new ActiveQuery(Order::class);
-        $order = $orderQuery->findOne(1);
+        $order = $orderQuery->findByPk(1);
 
         $customerQuery = $order->getCustomerQuery()->innerJoinWith(['orders o'], false);
 

--- a/tests/Driver/Pgsql/ActiveQueryTest.php
+++ b/tests/Driver/Pgsql/ActiveQueryTest.php
@@ -21,11 +21,11 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
         $this->checkFixture($this->db(), 'bit_values');
 
         $bitValueQuery = new ActiveQuery(BitValues::class);
-        $falseBit = $bitValueQuery->findOne(1);
+        $falseBit = $bitValueQuery->findByPk(1);
         $this->assertSame(0, $falseBit->val);
 
         $bitValueQuery = new ActiveQuery(BitValues::class);
-        $trueBit = $bitValueQuery->findOne(2);
+        $trueBit = $bitValueQuery->findByPk(2);
         $this->assertSame(1, $trueBit->val);
     }
 }

--- a/tests/MagicActiveRecordTest.php
+++ b/tests/MagicActiveRecordTest.php
@@ -6,7 +6,6 @@ namespace Yiisoft\ActiveRecord\Tests;
 
 use DateTimeImmutable;
 use DivisionByZeroError;
-use ReflectionException;
 use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord\Alpha;
 use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord\Animal;

--- a/tests/RepositoryTraitTest.php
+++ b/tests/RepositoryTraitTest.php
@@ -16,7 +16,7 @@ abstract class RepositoryTraitTest extends TestCase
         $customerQuery = new ActiveQuery(new CustomerWithRepositoryTrait());
 
         $this->assertEquals(
-            $customerQuery->find(['id' => 1]),
+            $customerQuery->setWhere(['id' => 1]),
             CustomerWithRepositoryTrait::find(['id' => 1]),
         );
     }
@@ -47,6 +47,18 @@ abstract class RepositoryTraitTest extends TestCase
         $this->assertEquals(
             $customerQuery->findAll(['id' => 1]),
             CustomerWithRepositoryTrait::findAll(['id' => 1]),
+        );
+    }
+
+    public function testFindByPk(): void
+    {
+        $this->checkFixture($this->db(), 'customer');
+
+        $customerQuery = new ActiveQuery(new CustomerWithRepositoryTrait());
+
+        $this->assertEquals(
+            $customerQuery->findByPk(1),
+            CustomerWithRepositoryTrait::findByPk(1),
         );
     }
 


### PR DESCRIPTION
- Add `ActiveQueryInterface::findByPk()` method
- Remove `ActiveQueryInterface::find()` method
- Replace `ActiveQueryInterface::findOne()` parameters
- Replace `ActiveQueryInterface::findAll()` parameters
- Make appropriate changes to `RepositoryTrait`

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #6, #67