### PR TITLE
Avoid `set` and `get` prefixes for AR methods

### DIFF
--- a/docs/create-model.md
+++ b/docs/create-model.md
@@ -26,7 +26,7 @@ use Yiisoft\ActiveRecord\ActiveRecord;
 #[\AllowDynamicProperties]
 final class User extends ActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return '{{%user}}';
     }
@@ -66,7 +66,7 @@ final class User extends ActiveRecord
     public string $email;
     public string $status = 'active';
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return '{{%user}}';
     }
@@ -96,7 +96,7 @@ final class User extends ActiveRecord
     protected string $email;
     protected string $status = 'active';
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return '{{%user}}';
     }
@@ -168,7 +168,7 @@ final class User extends ActiveRecord
     private string $email;
     private string $status = 'active';
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return '{{%user}}';
     }
@@ -213,7 +213,7 @@ final class User extends ActiveRecord
 {
     use MagicPropertiesTrait;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return '{{%user}}';
     }

--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -779,7 +779,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 
     protected function getPrimaryTableName(): string
     {
-        return $this->getARInstance()->getTableName();
+        return $this->getARInstance()->tableName();
     }
 
     public function getOn(): array|string|null
@@ -823,7 +823,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         }
 
         if (!empty($this->getJoins()) || !empty($this->getJoinWith())) {
-            $tableName = $arInstance->getTableName();
+            $tableName = $arInstance->tableName();
 
             foreach ($primaryKey as &$pk) {
                 $pk = "$tableName.$pk";

--- a/src/ActiveRecordInterface.php
+++ b/src/ActiveRecordInterface.php
@@ -84,7 +84,7 @@ interface ActiveRecordInterface
      * Returns a value indicating whether the given active record is the same as the current one.
      *
      * The comparison is made by comparing the table names and the primary key values of the two active records. If one
-     * of the records {@see getIsNewRecord|is new} they're also considered not equal.
+     * of the records {@see isNewRecord|is new} they're also considered not equal.
      *
      * @param self $record Record to compare to.
      *
@@ -124,7 +124,7 @@ interface ActiveRecordInterface
      *
      * @return bool Whether the record is new and should be inserted when calling {@see save()}.
      */
-    public function getIsNewRecord(): bool;
+    public function isNewRecord(): bool;
 
     /**
      * Returns the old value of the primary key as a scalar.
@@ -136,9 +136,9 @@ interface ActiveRecordInterface
      *
      * @throw Exception If multiple primary keys or no primary key.
      *
-     * @see getOldPrimaryKeys()
+     * @see primaryKeyOldValues()
      */
-    public function getOldPrimaryKey(): float|int|string|null;
+    public function primaryKeyOldValue(): float|int|string|null;
 
     /**
      * Returns the old values of the primary key as an array with property names as keys and property values as values.
@@ -150,25 +150,25 @@ interface ActiveRecordInterface
      *
      * @throw Exception If no primary key or multiple primary keys.
      *
-     * @see getOldPrimaryKeys()
+     * @see primaryKeyOldValues()
      */
-    public function getOldPrimaryKeys(): array;
+    public function primaryKeyOldValues(): array;
 
     /**
      * Returns the scalar value of the primary key.
      *
      * @throw Exception If multiple primary keys or no primary key.
      *
-     * @see getPrimaryKeys()
+     * @see primaryKeyValues()
      */
-    public function getPrimaryKey(): float|int|string|null;
+    public function primaryKeyValue(): float|int|string|null;
 
     /**
      * Returns the values of the primary key as an array with property names as keys and property values as values.
      *
-     * @see getPrimaryKey()
+     * @see primaryKeyValue()
      */
-    public function getPrimaryKeys(): array;
+    public function primaryKeyValues(): array;
 
     /**
      * Return the name of the table associated with this AR class.
@@ -178,13 +178,13 @@ interface ActiveRecordInterface
      * {
      *     public string const TABLE_NAME = 'user';
      *
-     *     public function getTableName(): string
+     *     public function tableName(): string
      *     {
      *          return self::TABLE_NAME;
      *     }
      * }
      */
-    public function getTableName(): string;
+    public function tableName(): string;
 
     /**
      * Returns a value indicating whether the record has a property with the specified name.
@@ -360,8 +360,8 @@ interface ActiveRecordInterface
     /**
      * Saves the current record.
      *
-     * This method will call {@see insert()} when {@see getIsNewRecord()|isNewRecord} is true, or {@see update()} when
-     * {@see getIsNewRecord()|isNewRecord} is false.
+     * This method will call {@see insert()} when {@see isNewRecord()|isNewRecord} is true, or {@see update()} when
+     * {@see isNewRecord()|isNewRecord} is false.
      *
      * For example, to save a customer record:
      *

--- a/src/ActiveRelationTrait.php
+++ b/src/ActiveRelationTrait.php
@@ -491,7 +491,7 @@ trait ActiveRelationTrait
     {
         if (!empty($this->join) || !empty($this->joinWith)) {
             if (empty($this->from)) {
-                $alias = $this->getARInstance()->getTableName();
+                $alias = $this->getARInstance()->tableName();
             } else {
                 $alias = array_key_first($this->from);
 

--- a/src/Trait/ArrayableTrait.php
+++ b/src/Trait/ArrayableTrait.php
@@ -17,8 +17,8 @@ use function array_keys;
  * @method string[] propertyNames()
  * @see ActiveRecordInterface::propertyNames()
  *
- * @method array getRelatedRecords()
- * @see AbstractActiveRecord::getRelatedRecords()
+ * @method array relatedRecords()
+ * @see AbstractActiveRecord::relatedRecords()
  */
 trait ArrayableTrait
 {
@@ -30,7 +30,7 @@ trait ArrayableTrait
      */
     public function extraFields(): array
     {
-        $fields = array_keys($this->getRelatedRecords());
+        $fields = array_keys($this->relatedRecords());
 
         return array_combine($fields, $fields);
     }

--- a/src/Trait/CustomTableNameTrait.php
+++ b/src/Trait/CustomTableNameTrait.php
@@ -7,7 +7,7 @@ namespace Yiisoft\ActiveRecord\Trait;
 /**
  * Trait to implement custom table name for ActiveRecord.
  *
- * @see ActiveRecordInterface::getTableName()
+ * @see ActiveRecordInterface::tableName()
  */
 trait CustomTableNameTrait
 {
@@ -23,8 +23,8 @@ trait CustomTableNameTrait
         return $new;
     }
 
-    public function getTableName(): string
+    public function tableName(): string
     {
-        return $this->tableName ??= parent::getTableName();
+        return $this->tableName ??= parent::tableName();
     }
 }

--- a/src/Trait/MagicPropertiesTrait.php
+++ b/src/Trait/MagicPropertiesTrait.php
@@ -22,8 +22,8 @@ use function property_exists;
 /**
  * Trait to define magic methods to access values of an ActiveRecord instance.
  *
- * @method array getRelatedRecords()
- * @see AbstractActiveRecord::getRelatedRecords()
+ * @method array relatedRecords()
+ * @see AbstractActiveRecord::relatedRecords()
  *
  * @method bool hasDependentRelations(string $propertyName)
  * @see AbstractActiveRecord::hasDependentRelations()
@@ -71,7 +71,7 @@ trait MagicPropertiesTrait
         }
 
         if ($this->isRelationPopulated($name)) {
-            return $this->getRelatedRecords()[$name];
+            return $this->relatedRecords()[$name];
         }
 
         if (method_exists($this, "get{$name}Query")) {

--- a/tests/ActiveQueryFindTest.php
+++ b/tests/ActiveQueryFindTest.php
@@ -380,7 +380,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
         $result = $customerQuery->setWhere(['name' => null])->all();
         $this->assertCount(1, $result);
-        $this->assertEquals(2, reset($result)->getPrimaryKey());
+        $this->assertEquals(2, reset($result)->primaryKeyValue());
     }
 
     public function testFindEager(): void
@@ -403,7 +403,7 @@ abstract class ActiveQueryFindTest extends TestCase
         $customer = $customerQuery->where(['id' => 1])->with('orders')->one();
         $this->assertTrue($customer->isRelationPopulated('orders'));
         $this->assertCount(1, $customer->getOrders());
-        $this->assertCount(1, $customer->getRelatedRecords());
+        $this->assertCount(1, $customer->relatedRecords());
 
         /** multiple with() calls */
         $orderQuery = new ActiveQuery(Order::class);
@@ -569,7 +569,7 @@ abstract class ActiveQueryFindTest extends TestCase
         $orders = $customer->getOrders();
         $this->assertTrue($customer->isRelationPopulated('orders'));
         $this->assertCount(2, $orders);
-        $this->assertCount(1, $customer->getRelatedRecords());
+        $this->assertCount(1, $customer->relatedRecords());
 
         $customer->resetRelation('orders');
         $this->assertFalse($customer->isRelationPopulated('orders'));
@@ -579,7 +579,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
         $orders = $customer->getOrdersQuery()->where(['id' => 3])->all();
         $this->assertFalse($customer->isRelationPopulated('orders'));
-        $this->assertCount(0, $customer->getRelatedRecords());
+        $this->assertCount(0, $customer->relatedRecords());
         $this->assertCount(1, $orders);
         $this->assertEquals(3, $orders[0]->getId());
     }

--- a/tests/ActiveQueryTest.php
+++ b/tests/ActiveQueryTest.php
@@ -1684,9 +1684,9 @@ abstract class ActiveQueryTest extends TestCase
         $customerQuery = new ActiveQuery(Customer::class);
 
         $query = $customerQuery->with('orders2')->where(['id' => 1])->one();
-        $this->assertCount(1, $query->getRelatedRecords());
+        $this->assertCount(1, $query->relatedRecords());
         $this->assertCount(1, $query->extraFields());
-        $this->assertArrayHasKey('orders2', $query->getRelatedRecords());
+        $this->assertArrayHasKey('orders2', $query->relatedRecords());
         $this->assertContains('orders2', $query->extraFields());
     }
 
@@ -1716,14 +1716,14 @@ abstract class ActiveQueryTest extends TestCase
         $order = new Order();
         $orderItem = new OrderItem();
 
-        $this->assertSame('order', $order->getTableName());
-        $this->assertSame('order_item', $orderItem->getTableName());
+        $this->assertSame('order', $order->tableName());
+        $this->assertSame('order_item', $orderItem->tableName());
 
         $order = $order->withTableName($orderTableName);
         $orderItem = $orderItem->withTableName($orderItemTableName);
 
-        $this->assertSame($orderTableName, $order->getTableName());
-        $this->assertSame($orderItemTableName, $orderItem->getTableName());
+        $this->assertSame($orderTableName, $order->tableName());
+        $this->assertSame($orderItemTableName, $orderItem->tableName());
 
         $orderQuery = new ActiveQuery(Order::class);
         $order = $orderQuery->findByPk(1);
@@ -1894,7 +1894,7 @@ abstract class ActiveQueryTest extends TestCase
 
         $this->assertSame(0, $document->version);
         $this->assertSame(1, $document->delete());
-        $this->assertTrue($document->getIsNewRecord());
+        $this->assertTrue($document->isNewRecord());
 
         $this->expectException(OptimisticLockException::class);
         $document->delete();
@@ -1938,7 +1938,7 @@ abstract class ActiveQueryTest extends TestCase
 
         /** @see https://github.com/yiisoft/yii2/issues/12143 */
         $newOrder = new Order();
-        $this->assertTrue($newOrder->getIsNewRecord());
+        $this->assertTrue($newOrder->isNewRecord());
 
         $this->expectException(InvalidCallException::class);
         $this->expectExceptionMessage('The record is new and cannot be updated.');
@@ -2288,13 +2288,13 @@ abstract class ActiveQueryTest extends TestCase
         $customer = $customerQuery->findByPk(2);
         $this->assertInstanceOf(Customer::class, $customer);
         $this->assertEquals('user2', $customer->get('name'));
-        $this->assertFalse($customer->getIsNewRecord());
+        $this->assertFalse($customer->isNewRecord());
         $this->assertEmpty($customer->newValues());
 
         $customer->set('name', 'user2x');
         $customer->save();
         $this->assertEquals('user2x', $customer->get('name'));
-        $this->assertFalse($customer->getIsNewRecord());
+        $this->assertFalse($customer->isNewRecord());
 
         $customer2 = $customerQuery->findByPk(2);
         $this->assertEquals('user2x', $customer2->get('name'));
@@ -2419,23 +2419,23 @@ abstract class ActiveQueryTest extends TestCase
 
         $order->setTotal(100);
         $order->setCreatedAt(time());
-        $this->assertTrue($order->getIsNewRecord());
+        $this->assertTrue($order->isNewRecord());
 
         /** belongs to */
         $order = new Order();
 
         $order->setTotal(100);
         $order->setCreatedAt(time());
-        $this->assertTrue($order->getIsNewRecord());
+        $this->assertTrue($order->isNewRecord());
 
         $customerQuery = new ActiveQuery(Customer::class);
         $customer = $customerQuery->findByPk(1);
         $this->assertNull($order->getCustomer());
 
         $order->link('customer', $customer);
-        $this->assertFalse($order->getIsNewRecord());
+        $this->assertFalse($order->isNewRecord());
         $this->assertEquals(1, $order->getCustomerId());
-        $this->assertEquals(1, $order->getCustomer()->getPrimaryKey());
+        $this->assertEquals(1, $order->getCustomer()->primaryKeyValue());
 
         /** via model */
         $orderQuery = new ActiveQuery(Order::class);

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -408,7 +408,7 @@ abstract class ActiveRecordTest extends TestCase
 
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage('The table does not exist: NoExist');
-        $noExist->getTableSchema();
+        $noExist->tableSchema();
     }
 
     public function testInsert(): void
@@ -422,12 +422,12 @@ abstract class ActiveRecordTest extends TestCase
         $customer->setAddress('address4');
 
         $this->assertNull($customer->get('id'));
-        $this->assertTrue($customer->getIsNewRecord());
+        $this->assertTrue($customer->isNewRecord());
 
         $customer->save();
 
         $this->assertNotNull($customer->getId());
-        $this->assertFalse($customer->getIsNewRecord());
+        $this->assertFalse($customer->isNewRecord());
     }
 
     /**
@@ -639,83 +639,83 @@ abstract class ActiveRecordTest extends TestCase
         $this->assertTrue($customer->save());
     }
 
-    public function testGetPrimaryKey(): void
+    public function testPrimaryKeyValue(): void
     {
         $customer = Customer::findByPk(1);
 
-        $this->assertSame(1, $customer->getPrimaryKey());
-        $this->assertSame(['id' => 1], $customer->getPrimaryKeys());
+        $this->assertSame(1, $customer->primaryKeyValue());
+        $this->assertSame(['id' => 1], $customer->primaryKeyValues());
 
         $orderItemQuery = new ActiveQuery(OrderItem::class);
         $orderItem = $orderItemQuery->findByPk([1, 2]);
 
-        $this->assertSame(['order_id' => 1, 'item_id' => 2], $orderItem->getPrimaryKeys());
+        $this->assertSame(['order_id' => 1, 'item_id' => 2], $orderItem->primaryKeyValues());
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage(OrderItem::class . ' has multiple primary keys. Use getPrimaryKeys() method instead.');
+        $this->expectExceptionMessage(OrderItem::class . ' has multiple primary keys. Use primaryKeyValues() method instead.');
 
-        $orderItem->getPrimaryKey();
+        $orderItem->primaryKeyValue();
     }
 
-    public function testGetPrimaryKeyWithoutPrimaryKey(): void
+    public function testPrimaryKeyValueWithoutPrimaryKey(): void
     {
         $orderItem = new OrderItemWithNullFK();
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(OrderItemWithNullFK::class . ' does not have a primary key.');
 
-        $orderItem->getPrimaryKey();
+        $orderItem->primaryKeyValue();
     }
 
-    public function testGetPrimaryKeysWithoutPrimaryKey(): void
+    public function testPrimaryKeyValuesWithoutPrimaryKey(): void
     {
         $orderItem = new OrderItemWithNullFK();
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(OrderItemWithNullFK::class . ' does not have a primary key.');
 
-        $orderItem->getPrimaryKeys();
+        $orderItem->primaryKeyValues();
     }
 
-    public function testGetOldPrimaryKey(): void
+    public function testPrimaryKeyOldValue(): void
     {
         $customer = Customer::findByPk(1);
         $customer->setId(2);
 
-        $this->assertSame(1, $customer->getOldPrimaryKey());
-        $this->assertSame(['id' => 1], $customer->getOldPrimaryKeys());
+        $this->assertSame(1, $customer->primaryKeyOldValue());
+        $this->assertSame(['id' => 1], $customer->primaryKeyOldValues());
 
         $orderItemQuery = new ActiveQuery(OrderItem::class);
         $orderItem = $orderItemQuery->findByPk([1, 2]);
         $orderItem->setOrderId(3);
         $orderItem->setItemId(4);
 
-        $this->assertSame(['order_id' => 1, 'item_id' => 2], $orderItem->getOldPrimaryKeys());
+        $this->assertSame(['order_id' => 1, 'item_id' => 2], $orderItem->primaryKeyOldValues());
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage(OrderItem::class . ' has multiple primary keys. Use getOldPrimaryKeys() method instead.');
+        $this->expectExceptionMessage(OrderItem::class . ' has multiple primary keys. Use primaryKeyOldValues() method instead.');
 
-        $orderItem->getOldPrimaryKey();
+        $orderItem->primaryKeyOldValue();
     }
 
-    public function testGetOldPrimaryKeyWithoutPrimaryKey(): void
+    public function testPrimaryKeyOldValueWithoutPrimaryKey(): void
     {
         $orderItem = new OrderItemWithNullFK();
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(OrderItemWithNullFK::class . ' does not have a primary key.');
 
-        $orderItem->getOldPrimaryKey();
+        $orderItem->primaryKeyOldValue();
     }
 
-    public function testGetOldPrimaryKeysWithoutPrimaryKey(): void
+    public function testPrimaryKeyOldValuesWithoutPrimaryKey(): void
     {
         $orderItem = new OrderItemWithNullFK();
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(OrderItemWithNullFK::class . ' does not have a primary key.');
 
-        $orderItem->getOldPrimaryKeys();
+        $orderItem->primaryKeyOldValues();
     }
 
     public function testGetDirtyValuesOnNewRecord(): void

--- a/tests/Driver/Mysql/ActiveRecordTest.php
+++ b/tests/Driver/Mysql/ActiveRecordTest.php
@@ -74,12 +74,12 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
         $customer->setName('user1337');
         $customer->setAddress('address1337');
 
-        $this->assertTrue($customer->getIsNewRecord());
+        $this->assertTrue($customer->isNewRecord());
 
         $customer->save();
 
         $this->assertEquals(1337, $customer->getId());
-        $this->assertFalse($customer->getIsNewRecord());
+        $this->assertFalse($customer->isNewRecord());
     }
 
     /**

--- a/tests/Driver/Mysql/MagicActiveRecordTest.php
+++ b/tests/Driver/Mysql/MagicActiveRecordTest.php
@@ -28,12 +28,12 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
         $customer->name = 'user1337';
         $customer->address = 'address1337';
 
-        $this->assertTrue($customer->isNewRecord);
+        $this->assertTrue($customer->isNewRecord());
 
         $customer->save();
 
         $this->assertEquals(1337, $customer->id);
-        $this->assertFalse($customer->isNewRecord);
+        $this->assertFalse($customer->isNewRecord());
     }
 
     /**

--- a/tests/Driver/Pgsql/ActiveRecordTest.php
+++ b/tests/Driver/Pgsql/ActiveRecordTest.php
@@ -108,11 +108,11 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
         $customer->setEmail('user1337@example.com');
         $customer->setName('user1337');
         $customer->setAddress('address1337');
-        $this->assertTrue($customer->getIsNewRecord());
+        $this->assertTrue($customer->isNewRecord());
 
         $customer->save();
         $this->assertEquals(1337, $customer->getId());
-        $this->assertFalse($customer->getIsNewRecord());
+        $this->assertFalse($customer->isNewRecord());
     }
 
     /**
@@ -227,7 +227,7 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
 
         $record->save();
 
-        $this->assertEquals(5, $record->getPrimaryKey());
+        $this->assertEquals(5, $record->primaryKeyValue());
     }
 
     public static function arrayValuesProvider(): array

--- a/tests/Driver/Pgsql/MagicActiveRecordTest.php
+++ b/tests/Driver/Pgsql/MagicActiveRecordTest.php
@@ -34,11 +34,11 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
         $customer->email = 'user1337@example.com';
         $customer->name = 'user1337';
         $customer->address = 'address1337';
-        $this->assertTrue($customer->isNewRecord);
+        $this->assertTrue($customer->isNewRecord());
 
         $customer->save();
         $this->assertEquals(1337, $customer->id);
-        $this->assertFalse($customer->isNewRecord);
+        $this->assertFalse($customer->isNewRecord());
     }
 
     /**
@@ -178,7 +178,7 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
 
         $record->save();
 
-        $this->assertEquals(5, $record->primaryKey);
+        $this->assertEquals(5, $record->primaryKeyValue());
     }
 
     public static function arrayValuesProvider(): array

--- a/tests/Driver/Pgsql/Stubs/Promotion.php
+++ b/tests/Driver/Pgsql/Stubs/Promotion.php
@@ -8,7 +8,7 @@ use Yiisoft\ActiveRecord\ActiveQueryInterface;
 
 final class Promotion extends \Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Promotion
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return '{{%promotion}}';
     }

--- a/tests/Driver/Sqlite/ActiveRecordTest.php
+++ b/tests/Driver/Sqlite/ActiveRecordTest.php
@@ -34,11 +34,11 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
         $customer->setName('user1337');
         $customer->setAddress('address1337');
 
-        $this->assertTrue($customer->getIsNewRecord());
+        $this->assertTrue($customer->isNewRecord());
         $customer->save();
 
         $this->assertEquals(1337, $customer->getId());
-        $this->assertFalse($customer->getIsNewRecord());
+        $this->assertFalse($customer->isNewRecord());
     }
 
     /**

--- a/tests/Driver/Sqlite/MagicActiveRecordTest.php
+++ b/tests/Driver/Sqlite/MagicActiveRecordTest.php
@@ -28,11 +28,11 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
         $customer->name = 'user1337';
         $customer->address = 'address1337';
 
-        $this->assertTrue($customer->isNewRecord);
+        $this->assertTrue($customer->isNewRecord());
         $customer->save();
 
         $this->assertEquals(1337, $customer->id);
-        $this->assertFalse($customer->isNewRecord);
+        $this->assertFalse($customer->isNewRecord());
     }
 
     /**

--- a/tests/MagicActiveRecordTest.php
+++ b/tests/MagicActiveRecordTest.php
@@ -397,7 +397,7 @@ abstract class MagicActiveRecordTest extends TestCase
 
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage('The table does not exist: NoExist');
-        $noExist->getTableSchema();
+        $noExist->tableSchema();
     }
 
     public function testInsert(): void
@@ -411,12 +411,12 @@ abstract class MagicActiveRecordTest extends TestCase
         $customer->address = 'address4';
 
         $this->assertNull($customer->id);
-        $this->assertTrue($customer->isNewRecord);
+        $this->assertTrue($customer->isNewRecord());
 
         $customer->save();
 
         $this->assertNotNull($customer->id);
-        $this->assertFalse($customer->isNewRecord);
+        $this->assertFalse($customer->isNewRecord());
     }
 
     /**
@@ -626,83 +626,83 @@ abstract class MagicActiveRecordTest extends TestCase
         $this->assertTrue($customer->save());
     }
 
-    public function testGetPrimaryKey(): void
+    public function testPrimaryKeyValue(): void
     {
         $customer = Customer::findByPk(1);
 
-        $this->assertSame(1, $customer->getPrimaryKey());
-        $this->assertSame(['id' => 1], $customer->getPrimaryKeys());
+        $this->assertSame(1, $customer->primaryKeyValue());
+        $this->assertSame(['id' => 1], $customer->primaryKeyValues());
 
         $orderItemQuery = new ActiveQuery(OrderItem::class);
         $orderItem = $orderItemQuery->findByPk([1, 2]);
 
-        $this->assertSame(['order_id' => 1, 'item_id' => 2], $orderItem->getPrimaryKeys());
+        $this->assertSame(['order_id' => 1, 'item_id' => 2], $orderItem->primaryKeyValues());
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage(OrderItem::class . ' has multiple primary keys. Use getPrimaryKeys() method instead.');
+        $this->expectExceptionMessage(OrderItem::class . ' has multiple primary keys. Use primaryKeyValues() method instead.');
 
-        $orderItem->getPrimaryKey();
+        $orderItem->primaryKeyValue();
     }
 
-    public function testGetPrimaryKeyWithoutPrimaryKey(): void
+    public function testPrimaryKeyValueWithoutPrimaryKey(): void
     {
         $orderItem = new OrderItemWithNullFK();
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(OrderItemWithNullFK::class . ' does not have a primary key.');
 
-        $orderItem->getPrimaryKey();
+        $orderItem->primaryKeyValue();
     }
 
-    public function testGetPrimaryKeysWithoutPrimaryKey(): void
+    public function testPrimaryKeyValuesWithoutPrimaryKey(): void
     {
         $orderItem = new OrderItemWithNullFK();
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(OrderItemWithNullFK::class . ' does not have a primary key.');
 
-        $orderItem->getPrimaryKeys();
+        $orderItem->primaryKeyValues();
     }
 
-    public function testGetOldPrimaryKey(): void
+    public function testPrimaryKeyOldValue(): void
     {
         $customer = Customer::findByPk(1);
         $customer->id = 2;
 
-        $this->assertSame(1, $customer->getOldPrimaryKey());
-        $this->assertSame(['id' => 1], $customer->getOldPrimaryKeys());
+        $this->assertSame(1, $customer->primaryKeyOldValue());
+        $this->assertSame(['id' => 1], $customer->primaryKeyOldValues());
 
         $orderItemQuery = new ActiveQuery(OrderItem::class);
         $orderItem = $orderItemQuery->findByPk([1, 2]);
         $orderItem->order_id = 3;
         $orderItem->item_id = 4;
 
-        $this->assertSame(['order_id' => 1, 'item_id' => 2], $orderItem->getOldPrimaryKeys());
+        $this->assertSame(['order_id' => 1, 'item_id' => 2], $orderItem->primaryKeyOldValues());
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage(OrderItem::class . ' has multiple primary keys. Use getOldPrimaryKeys() method instead.');
+        $this->expectExceptionMessage(OrderItem::class . ' has multiple primary keys. Use primaryKeyOldValues() method instead.');
 
-        $orderItem->getOldPrimaryKey();
+        $orderItem->primaryKeyOldValue();
     }
 
-    public function testGetOldPrimaryKeyWithoutPrimaryKey(): void
+    public function testPrimaryKeyOldValueWithoutPrimaryKey(): void
     {
         $orderItem = new OrderItemWithNullFK();
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(OrderItemWithNullFK::class . ' does not have a primary key.');
 
-        $orderItem->getOldPrimaryKey();
+        $orderItem->primaryKeyOldValue();
     }
 
-    public function testGetOldPrimaryKeysWithoutPrimaryKey(): void
+    public function testPrimaryKeyOldValuesWithoutPrimaryKey(): void
     {
         $orderItem = new OrderItemWithNullFK();
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(OrderItemWithNullFK::class . ' does not have a primary key.');
 
-        $orderItem->getOldPrimaryKeys();
+        $orderItem->primaryKeyOldValues();
     }
 
     public function testGetDirtyValuesOnNewRecord(): void

--- a/tests/Stubs/ActiveRecord/Alpha.php
+++ b/tests/Stubs/ActiveRecord/Alpha.php
@@ -16,7 +16,7 @@ final class Alpha extends ActiveRecord
 
     protected string $string_identifier;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return self::TABLE_NAME;
     }

--- a/tests/Stubs/ActiveRecord/Animal.php
+++ b/tests/Stubs/ActiveRecord/Animal.php
@@ -16,7 +16,7 @@ class Animal extends ActiveRecord
     protected int $id;
     protected string $type;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'animal';
     }

--- a/tests/Stubs/ActiveRecord/Beta.php
+++ b/tests/Stubs/ActiveRecord/Beta.php
@@ -14,7 +14,7 @@ final class Beta extends ActiveRecord
     protected string $alpha_string_identifier;
     protected Alpha $alpha;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'beta';
     }

--- a/tests/Stubs/ActiveRecord/BoolAR.php
+++ b/tests/Stubs/ActiveRecord/BoolAR.php
@@ -13,7 +13,7 @@ final class BoolAR extends ActiveRecord
     public bool $default_true = true;
     public bool $default_false = false;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'bool_values';
     }

--- a/tests/Stubs/ActiveRecord/Category.php
+++ b/tests/Stubs/ActiveRecord/Category.php
@@ -16,7 +16,7 @@ final class Category extends ActiveRecord
     protected int|null $id;
     protected string $name;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'category';
     }

--- a/tests/Stubs/ActiveRecord/Customer.php
+++ b/tests/Stubs/ActiveRecord/Customer.php
@@ -36,7 +36,7 @@ class Customer extends ArrayableActiveRecord
      */
     public $sumTotal;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'customer';
     }

--- a/tests/Stubs/ActiveRecord/CustomerClosureField.php
+++ b/tests/Stubs/ActiveRecord/CustomerClosureField.php
@@ -19,7 +19,7 @@ final class CustomerClosureField extends ArrayableActiveRecord
     protected bool|string|null $bool_status = false;
     protected int|null $profile_id = null;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'customer';
     }

--- a/tests/Stubs/ActiveRecord/CustomerForArrayable.php
+++ b/tests/Stubs/ActiveRecord/CustomerForArrayable.php
@@ -23,7 +23,7 @@ class CustomerForArrayable extends ArrayableActiveRecord
     protected bool|string|null $bool_status = false;
     protected int|null $profile_id = null;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'customer';
     }

--- a/tests/Stubs/ActiveRecord/CustomerWithAlias.php
+++ b/tests/Stubs/ActiveRecord/CustomerWithAlias.php
@@ -25,7 +25,7 @@ final class CustomerWithAlias extends ActiveRecord
     public bool|string|null $bool_status = null;
     public int|null $profile_id = null;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'customer';
     }

--- a/tests/Stubs/ActiveRecord/DefaultPk.php
+++ b/tests/Stubs/ActiveRecord/DefaultPk.php
@@ -11,7 +11,7 @@ final class DefaultPk extends ActiveRecord
     public int $id;
     public string $type;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'default_pk';
     }

--- a/tests/Stubs/ActiveRecord/Department.php
+++ b/tests/Stubs/ActiveRecord/Department.php
@@ -17,7 +17,7 @@ final class Department extends ActiveRecord
     protected int $id;
     protected string $title;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'department';
     }

--- a/tests/Stubs/ActiveRecord/Dossier.php
+++ b/tests/Stubs/ActiveRecord/Dossier.php
@@ -18,7 +18,7 @@ final class Dossier extends ActiveRecord
     protected int $employee_id;
     protected string $summary;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'dossier';
     }

--- a/tests/Stubs/ActiveRecord/Employee.php
+++ b/tests/Stubs/ActiveRecord/Employee.php
@@ -18,7 +18,7 @@ final class Employee extends ActiveRecord
     protected string $first_name;
     protected string $last_name;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'employee';
     }

--- a/tests/Stubs/ActiveRecord/Item.php
+++ b/tests/Stubs/ActiveRecord/Item.php
@@ -17,7 +17,7 @@ class Item extends ActiveRecord
     protected string $name;
     protected int $category_id;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'item';
     }

--- a/tests/Stubs/ActiveRecord/NoExist.php
+++ b/tests/Stubs/ActiveRecord/NoExist.php
@@ -8,7 +8,7 @@ use Yiisoft\ActiveRecord\ActiveRecord;
 
 final class NoExist extends ActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'NoExist';
     }

--- a/tests/Stubs/ActiveRecord/NullValues.php
+++ b/tests/Stubs/ActiveRecord/NullValues.php
@@ -18,7 +18,7 @@ use Yiisoft\ActiveRecord\ActiveRecord;
 #[\AllowDynamicProperties]
 final class NullValues extends ActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'null_values';
     }

--- a/tests/Stubs/ActiveRecord/Order.php
+++ b/tests/Stubs/ActiveRecord/Order.php
@@ -25,7 +25,7 @@ class Order extends ActiveRecord
 
     protected string|int|null $virtualCustomerId = null;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return $this->tableName ??= self::TABLE_NAME;
     }

--- a/tests/Stubs/ActiveRecord/OrderItem.php
+++ b/tests/Stubs/ActiveRecord/OrderItem.php
@@ -21,7 +21,7 @@ final class OrderItem extends ActiveRecord
     protected int $quantity;
     protected float $subtotal;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return $this->tableName ??= 'order_item';
     }

--- a/tests/Stubs/ActiveRecord/OrderItemWithNullFK.php
+++ b/tests/Stubs/ActiveRecord/OrderItemWithNullFK.php
@@ -16,7 +16,7 @@ final class OrderItemWithNullFK extends ActiveRecord
     protected int $quantity;
     protected float $subtotal;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'order_item_with_null_fk';
     }

--- a/tests/Stubs/ActiveRecord/OrderWithNullFK.php
+++ b/tests/Stubs/ActiveRecord/OrderWithNullFK.php
@@ -16,7 +16,7 @@ final class OrderWithNullFK extends ActiveRecord
     protected int $created_at;
     protected float $total;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'order_with_null_fk';
     }

--- a/tests/Stubs/ActiveRecord/Profile.php
+++ b/tests/Stubs/ActiveRecord/Profile.php
@@ -16,7 +16,7 @@ final class Profile extends ActiveRecord
     protected int $id;
     protected string $description;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return self::TABLE_NAME;
     }

--- a/tests/Stubs/ActiveRecord/ProfileWithConstructor.php
+++ b/tests/Stubs/ActiveRecord/ProfileWithConstructor.php
@@ -21,7 +21,7 @@ final class ProfileWithConstructor extends ActiveRecord
         parent::__construct($db);
     }
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'profile';
     }

--- a/tests/Stubs/ActiveRecord/Promotion.php
+++ b/tests/Stubs/ActiveRecord/Promotion.php
@@ -16,7 +16,7 @@ class Promotion extends ActiveRecord
     public array $json_item_ids;
     public string $title;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return '{{%promotion}}';
     }

--- a/tests/Stubs/ActiveRecord/TestTrigger.php
+++ b/tests/Stubs/ActiveRecord/TestTrigger.php
@@ -14,7 +14,7 @@ final class TestTrigger extends ActiveRecord
     public int $id;
     public string $stringcol;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'test_trigger';
     }

--- a/tests/Stubs/ActiveRecord/TestTriggerAlert.php
+++ b/tests/Stubs/ActiveRecord/TestTriggerAlert.php
@@ -14,7 +14,7 @@ final class TestTriggerAlert extends ActiveRecord
     public int $id;
     public string $stringcol;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'test_trigger_alert';
     }

--- a/tests/Stubs/ActiveRecord/Type.php
+++ b/tests/Stubs/ActiveRecord/Type.php
@@ -31,7 +31,7 @@ class Type extends ActiveRecord
     public int|string $bit_col = 0b1000_0010;
     public array|null $json_col = null;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'type';
     }

--- a/tests/Stubs/ActiveRecord/UserAR.php
+++ b/tests/Stubs/ActiveRecord/UserAR.php
@@ -24,7 +24,7 @@ final class UserAR extends ActiveRecord
     public int $updated_at;
     public bool $is_deleted = false;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return '{{%bool_user}}';
     }

--- a/tests/Stubs/MagicActiveRecord/Alpha.php
+++ b/tests/Stubs/MagicActiveRecord/Alpha.php
@@ -15,7 +15,7 @@ final class Alpha extends MagicActiveRecord
 {
     public const TABLE_NAME = 'alpha';
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return self::TABLE_NAME;
     }

--- a/tests/Stubs/MagicActiveRecord/Animal.php
+++ b/tests/Stubs/MagicActiveRecord/Animal.php
@@ -16,7 +16,7 @@ class Animal extends MagicActiveRecord
 {
     private string $does;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'animal';
     }

--- a/tests/Stubs/MagicActiveRecord/Beta.php
+++ b/tests/Stubs/MagicActiveRecord/Beta.php
@@ -14,7 +14,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
  */
 final class Beta extends MagicActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'beta';
     }

--- a/tests/Stubs/MagicActiveRecord/BoolAR.php
+++ b/tests/Stubs/MagicActiveRecord/BoolAR.php
@@ -8,7 +8,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
 
 final class BoolAR extends MagicActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'bool_values';
     }

--- a/tests/Stubs/MagicActiveRecord/Category.php
+++ b/tests/Stubs/MagicActiveRecord/Category.php
@@ -15,7 +15,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
  */
 final class Category extends MagicActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'category';
     }

--- a/tests/Stubs/MagicActiveRecord/Customer.php
+++ b/tests/Stubs/MagicActiveRecord/Customer.php
@@ -34,7 +34,7 @@ class Customer extends MagicActiveRecord
      */
     public $sumTotal;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'customer';
     }

--- a/tests/Stubs/MagicActiveRecord/CustomerWithAlias.php
+++ b/tests/Stubs/MagicActiveRecord/CustomerWithAlias.php
@@ -25,7 +25,7 @@ final class CustomerWithAlias extends MagicActiveRecord
     public int $status2;
     public float $sumTotal;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'customer';
     }

--- a/tests/Stubs/MagicActiveRecord/CustomerWithProperties.php
+++ b/tests/Stubs/MagicActiveRecord/CustomerWithProperties.php
@@ -17,7 +17,7 @@ class CustomerWithProperties extends MagicActiveRecord
     protected string|null $name = null;
     public string|null $address = null;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'customer';
     }

--- a/tests/Stubs/MagicActiveRecord/DefaultPk.php
+++ b/tests/Stubs/MagicActiveRecord/DefaultPk.php
@@ -8,7 +8,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
 
 final class DefaultPk extends MagicActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'default_pk';
     }

--- a/tests/Stubs/MagicActiveRecord/Department.php
+++ b/tests/Stubs/MagicActiveRecord/Department.php
@@ -16,7 +16,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
  */
 final class Department extends MagicActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'department';
     }

--- a/tests/Stubs/MagicActiveRecord/Dossier.php
+++ b/tests/Stubs/MagicActiveRecord/Dossier.php
@@ -18,7 +18,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
  */
 final class Dossier extends MagicActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'dossier';
     }

--- a/tests/Stubs/MagicActiveRecord/Employee.php
+++ b/tests/Stubs/MagicActiveRecord/Employee.php
@@ -20,7 +20,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
  */
 final class Employee extends MagicActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'employee';
     }

--- a/tests/Stubs/MagicActiveRecord/Item.php
+++ b/tests/Stubs/MagicActiveRecord/Item.php
@@ -16,7 +16,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
  */
 final class Item extends MagicActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'item';
     }

--- a/tests/Stubs/MagicActiveRecord/NoExist.php
+++ b/tests/Stubs/MagicActiveRecord/NoExist.php
@@ -8,7 +8,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
 
 final class NoExist extends MagicActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'NoExist';
     }

--- a/tests/Stubs/MagicActiveRecord/NullValues.php
+++ b/tests/Stubs/MagicActiveRecord/NullValues.php
@@ -17,7 +17,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
  */
 final class NullValues extends MagicActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'null_values';
     }

--- a/tests/Stubs/MagicActiveRecord/Order.php
+++ b/tests/Stubs/MagicActiveRecord/Order.php
@@ -23,7 +23,7 @@ class Order extends MagicActiveRecord
 
     private string|int|null $virtualCustomerId = null;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return self::TABLE_NAME;
     }

--- a/tests/Stubs/MagicActiveRecord/OrderItem.php
+++ b/tests/Stubs/MagicActiveRecord/OrderItem.php
@@ -17,7 +17,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
  */
 final class OrderItem extends MagicActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'order_item';
     }

--- a/tests/Stubs/MagicActiveRecord/OrderItemWithNullFK.php
+++ b/tests/Stubs/MagicActiveRecord/OrderItemWithNullFK.php
@@ -16,7 +16,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
  */
 final class OrderItemWithNullFK extends MagicActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'order_item_with_null_fk';
     }

--- a/tests/Stubs/MagicActiveRecord/OrderWithNullFK.php
+++ b/tests/Stubs/MagicActiveRecord/OrderWithNullFK.php
@@ -16,7 +16,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
  */
 final class OrderWithNullFK extends MagicActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'order_with_null_fk';
     }

--- a/tests/Stubs/MagicActiveRecord/Profile.php
+++ b/tests/Stubs/MagicActiveRecord/Profile.php
@@ -16,7 +16,7 @@ final class Profile extends MagicActiveRecord
 {
     public const TABLE_NAME = 'profile';
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return self::TABLE_NAME;
     }

--- a/tests/Stubs/MagicActiveRecord/ProfileWithConstructor.php
+++ b/tests/Stubs/MagicActiveRecord/ProfileWithConstructor.php
@@ -21,7 +21,7 @@ final class ProfileWithConstructor extends MagicActiveRecord
         parent::__construct($db);
     }
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'profile';
     }

--- a/tests/Stubs/MagicActiveRecord/TestTrigger.php
+++ b/tests/Stubs/MagicActiveRecord/TestTrigger.php
@@ -14,7 +14,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
  */
 final class TestTrigger extends MagicActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'test_trigger';
     }

--- a/tests/Stubs/MagicActiveRecord/TestTriggerAlert.php
+++ b/tests/Stubs/MagicActiveRecord/TestTriggerAlert.php
@@ -14,7 +14,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
  */
 final class TestTriggerAlert extends MagicActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'test_trigger_alert';
     }

--- a/tests/Stubs/MagicActiveRecord/Type.php
+++ b/tests/Stubs/MagicActiveRecord/Type.php
@@ -26,7 +26,7 @@ use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord;
  */
 final class Type extends MagicActiveRecord
 {
-    public function getTableName(): string
+    public function tableName(): string
     {
         return 'type';
     }

--- a/tests/Stubs/MagicActiveRecord/UserAR.php
+++ b/tests/Stubs/MagicActiveRecord/UserAR.php
@@ -12,7 +12,7 @@ final class UserAR extends MagicActiveRecord
     public const STATUS_ACTIVE = 10;
     public const ROLE_USER = 10;
 
-    public function getTableName(): string
+    public function tableName(): string
     {
         return '{{%bool_user}}';
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #358
