### PR TITLE
Rename `getAR*()` methods to `getAr*()`

### DIFF
--- a/src/AbstractActiveRecord.php
+++ b/src/AbstractActiveRecord.php
@@ -432,7 +432,7 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
             if (is_array($via)) {
                 [$viaName, $viaRelation] = $via;
                 /** @psalm-var ActiveQueryInterface $viaRelation */
-                $viaClass = $viaRelation->getARInstance();
+                $viaClass = $viaRelation->getArInstance();
                 // unset $viaName so that it can be reloaded to reflect the change.
                 /** @psalm-var string $viaName */
                 unset($this->related[$viaName]);
@@ -825,7 +825,7 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
             if (is_array($viaRelation)) {
                 [$viaName, $viaRelation] = $viaRelation;
                 /** @psalm-var ActiveQueryInterface $viaRelation */
-                $viaClass = $viaRelation->getARInstance();
+                $viaClass = $viaRelation->getArInstance();
                 /** @psalm-var string $viaName */
                 unset($this->related[$viaName]);
             }
@@ -941,7 +941,7 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
             if (is_array($viaRelation)) {
                 [$viaName, $viaRelation] = $viaRelation;
                 /** @psalm-var ActiveQueryInterface $viaRelation */
-                $viaClass = $viaRelation->getARInstance();
+                $viaClass = $viaRelation->getArInstance();
                 /** @psalm-var string $viaName */
                 unset($this->related[$viaName]);
             } else {
@@ -984,7 +984,7 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
                 }
             }
         } else {
-            $relatedModel = $relation->getARInstance();
+            $relatedModel = $relation->getArInstance();
 
             $link = $relation->getLink();
             if (!$delete && count($link) === 1 && is_array($this->get($b = reset($link)))) {

--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -120,7 +120,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     final public function __construct(
         protected string|ActiveRecordInterface|Closure $arClass
     ) {
-        parent::__construct($this->getARInstance()->db());
+        parent::__construct($this->getArInstance()->db());
     }
 
     public function each(): DataReaderInterface
@@ -273,7 +273,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      */
     private function removeDuplicatedRows(array $rows): array
     {
-        $instance = $this->getARInstance();
+        $instance = $this->getArInstance();
         $pks = $instance->primaryKey();
 
         if (empty($pks)) {
@@ -416,7 +416,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 
         $this->join = [];
 
-        $arClass = $this->getARInstance();
+        $arClass = $this->getArInstance();
 
         foreach ($this->joinWith as [$with, $eagerLoading, $joinType]) {
             $this->joinWithRelations($arClass, $with, $joinType);
@@ -517,7 +517,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
                 }
 
                 if ($relation instanceof ActiveQueryInterface) {
-                    $primaryModel = $relation->getARInstance();
+                    $primaryModel = $relation->getArInstance();
                     $parent = $relation;
                 }
 
@@ -779,7 +779,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 
     protected function getPrimaryTableName(): string
     {
-        return $this->getARInstance()->tableName();
+        return $this->getArInstance()->tableName();
     }
 
     public function getOn(): array|string|null
@@ -800,7 +800,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         return $this->sql;
     }
 
-    public function getARClass(): string|ActiveRecordInterface|Closure
+    public function getArClass(): string|ActiveRecordInterface|Closure
     {
         return $this->arClass;
     }
@@ -809,7 +809,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     {
         $values = (array) $values;
 
-        $arInstance = $this->getARInstance();
+        $arInstance = $this->getArInstance();
         $primaryKey = $arInstance->primaryKey();
 
         if (empty($primaryKey)) {
@@ -845,7 +845,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         return $this;
     }
 
-    public function getARInstance(): ActiveRecordInterface
+    public function getArInstance(): ActiveRecordInterface
     {
         if ($this->arClass instanceof ActiveRecordInterface) {
             return clone $this->arClass;

--- a/src/ActiveQueryInterface.php
+++ b/src/ActiveQueryInterface.php
@@ -317,7 +317,7 @@ interface ActiveQueryInterface extends QueryInterface
      *
      * @psalm-return ARClass
      */
-    public function getARClass(): string|ActiveRecordInterface|Closure;
+    public function getArClass(): string|ActiveRecordInterface|Closure;
 
     public function on(array|string|null $value): static;
 
@@ -455,7 +455,7 @@ interface ActiveQueryInterface extends QueryInterface
      * @throws NotInstantiableException
      * @return ActiveRecordInterface The model instance associated with this query.
      */
-    public function getARInstance(): ActiveRecordInterface;
+    public function getArInstance(): ActiveRecordInterface;
 
     /**
      * @return bool Whether this query represents a relation to more than one record.

--- a/src/ActiveQueryTrait.php
+++ b/src/ActiveQueryTrait.php
@@ -129,7 +129,7 @@ trait ActiveQueryTrait
         $models = [];
 
         foreach ($rows as $row) {
-            $arClass = $this->getARInstance();
+            $arClass = $this->getArInstance();
             $arClass->populateRecord($row);
 
             $models[] = $arClass;
@@ -159,7 +159,7 @@ trait ActiveQueryTrait
         $primaryModel = reset($models);
 
         if (!$primaryModel instanceof ActiveRecordInterface) {
-            $primaryModel = $this->getARInstance();
+            $primaryModel = $this->getArInstance();
         }
 
         $relations = $this->normalizeRelations($primaryModel, $with);

--- a/src/ActiveRelationTrait.php
+++ b/src/ActiveRelationTrait.php
@@ -223,7 +223,7 @@ trait ActiveRelationTrait
                 $relatedModel->populateRelation($this->inverseOf, $primaryModel);
             }
         } else {
-            $inverseRelation = $this->getARInstance()->relationQuery($this->inverseOf);
+            $inverseRelation = $this->getArInstance()->relationQuery($this->inverseOf);
             $primaryModel = $inverseRelation->getMultiple() ? [$this->primaryModel] : $this->primaryModel;
 
             /** @var array $relatedModel */
@@ -338,7 +338,7 @@ trait ActiveRelationTrait
 
         /** @var ActiveQuery $relation */
         $relation = is_array($model)
-            ? $this->getARInstance()->relationQuery($name)
+            ? $this->getArInstance()->relationQuery($name)
             : $model->relationQuery($name);
 
         $link = $relation->getLink();
@@ -492,7 +492,7 @@ trait ActiveRelationTrait
     {
         if (!empty($this->join) || !empty($this->joinWith)) {
             if (empty($this->from)) {
-                $alias = $this->getARInstance()->tableName();
+                $alias = $this->getArInstance()->tableName();
             } else {
                 $alias = array_key_first($this->from);
 
@@ -570,7 +570,7 @@ trait ActiveRelationTrait
             /** @var string $propertyName */
             $propertyName = array_key_first($this->link);
 
-            match ($this->getARInstance()->columnType($propertyName)) {
+            match ($this->getArInstance()->columnType($propertyName)) {
                 ColumnType::ARRAY => $this->andWhere(new ArrayOverlapsCondition($columnName, $values)),
                 ColumnType::JSON => $this->andWhere(new JsonOverlapsCondition($columnName, $values)),
                 default => $this->andWhere(new InCondition($columnName, 'IN', $values)),

--- a/tests/ActiveQueryTest.php
+++ b/tests/ActiveQueryTest.php
@@ -40,7 +40,7 @@ abstract class ActiveQueryTest extends TestCase
         $customerQuery = new ActiveQuery(Customer::class);
 
         $query = $customerQuery->on(['a' => 'b'])->joinWith('profile');
-        $this->assertEquals(Customer::class, $query->getARClass());
+        $this->assertEquals(Customer::class, $query->getArClass());
         $this->assertEquals(['a' => 'b'], $query->getOn());
         $this->assertEquals([[['profile'], true, 'LEFT JOIN']], $query->getJoinWith());
         $customerQuery->resetJoinWith();
@@ -2503,8 +2503,8 @@ abstract class ActiveQueryTest extends TestCase
     {
         $query = new ActiveQuery(Customer::class);
 
-        $this->assertSame(Customer::class, $query->getARClass());
-        $this->assertInstanceOf(Customer::class, $query->getARInstance());
+        $this->assertSame(Customer::class, $query->getArClass());
+        $this->assertInstanceOf(Customer::class, $query->getArInstance());
     }
 
     public function testARClassAsInstance(): void
@@ -2512,8 +2512,8 @@ abstract class ActiveQueryTest extends TestCase
         $customer = new Customer();
         $query = new ActiveQuery($customer);
 
-        $this->assertSame($customer, $query->getARClass());
-        $this->assertInstanceOf(Customer::class, $query->getARInstance());
+        $this->assertSame($customer, $query->getArClass());
+        $this->assertInstanceOf(Customer::class, $query->getArInstance());
     }
 
     public function testARClassAsClosure(): void
@@ -2521,7 +2521,7 @@ abstract class ActiveQueryTest extends TestCase
         $closure = fn (): Customer => new Customer();
         $query = new ActiveQuery($closure);
 
-        $this->assertSame($closure, $query->getARClass());
-        $this->assertInstanceOf(Customer::class, $query->getARInstance());
+        $this->assertSame($closure, $query->getArClass());
+        $this->assertInstanceOf(Customer::class, $query->getArInstance());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

