### PR TITLE
Make `ActiveRecordInterface::query()` method `static`

### DIFF
--- a/docs/create-model.md
+++ b/docs/create-model.md
@@ -274,9 +274,7 @@ Now you can use `$user->getProfile()` and `$user->getOrders()` to access the rel
 ```php
 use Yiisoft\ActiveRecord\ActiveQuery;
 
-$userQuery = new ActiveQuery(User::class);
-
-$user = $userQuery->where(['id' => 1])->one();
+$user = User::query()->where(['id' => 1])->one();
 
 $profile = $user->getProfile();
 $orders = $user->getOrders();

--- a/docs/define-relations.md
+++ b/docs/define-relations.md
@@ -402,9 +402,7 @@ To do this, use the `ActiveQueryInterface::with()` method.
 ```php
 use Yiisoft\ActiveRecord\ActiveQuery;
 
-$userQuery = new ActiveQuery(User::class);
-
-$users = $userQuery->with('profile', 'orders')->all();
+$users = User::query()->with('profile', 'orders')->all();
 ```
 
 In the example, `profile` and `orders` are the relation names that you want to load in advance.
@@ -451,9 +449,7 @@ Now you can use `$user->getProfile()` and `$user->getOrders()` to access the rel
 ```php
 use Yiisoft\ActiveRecord\ActiveQuery;
 
-$userQuery = (new ActiveQuery(User::class))->where(['id' => 1]);
-
-$user = $userQuery->one();
+$user = User::query()->where(['id' => 1])->one();
 
 $profile = $user->getProfile();
 $orders = $user->getOrders();

--- a/docs/optimistic-locking.md
+++ b/docs/optimistic-locking.md
@@ -114,7 +114,7 @@ final class DocumentController
     ): ResponseInterface {
         $id = (int) $request->getAttribute('id');
 
-        $document = (new ActiveQuery(Document::class))->findByPk($id);
+        $document = Document::query()->findByPk($id);
 
         if ($document === null) {
             throw new NotFoundException('Document not found.');
@@ -129,7 +129,7 @@ final class DocumentController
         $data = $request->getParsedBody();
         
         $id = (int) $data['id'];
-        $document = (new ActiveQuery(Document::class))->findByPk($id);
+        $document = Document::query()->findByPk($id);
 
         if ($document === null) {
             throw new NotFoundException('Document not found.');

--- a/src/AbstractActiveRecord.php
+++ b/src/AbstractActiveRecord.php
@@ -98,13 +98,6 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
         array|bool $updateProperties = true,
     ): bool;
 
-    /**
-     * @param ActiveRecordInterface|Closure|string|null $modelClass The class name of the related record, or an instance
-     * of the related record, or a Closure to create an {@see ActiveRecordInterface} object. If `null`, the current model
-     * will be used.
-     *
-     * @psalm-param ModelClass $modelClass
-     */
     public function createQuery(ActiveRecordInterface|Closure|null|string $modelClass = null): ActiveQueryInterface
     {
         return static::query($modelClass);

--- a/src/AbstractActiveRecord.php
+++ b/src/AbstractActiveRecord.php
@@ -98,6 +98,18 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
         array|bool $updateProperties = true,
     ): bool;
 
+    /**
+     * @param ActiveRecordInterface|Closure|string|null $modelClass The class name of the related record, or an instance
+     * of the related record, or a Closure to create an {@see ActiveRecordInterface} object. If `null`, the current model
+     * will be used.
+     *
+     * @psalm-param ModelClass $modelClass
+     */
+    public function createQuery(ActiveRecordInterface|Closure|null|string $modelClass = null): ActiveQueryInterface
+    {
+        return static::query($modelClass);
+    }
+
     public function delete(): int
     {
         return $this->deleteInternal();
@@ -363,18 +375,6 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
         return $this->insertInternal($properties);
     }
 
-    /**
-     * @param ActiveRecordInterface|Closure|string|null $modelClass The class name of the related record, or an instance of
-     * the related record, or a Closure to create an {@see ActiveRecordInterface} object. If `null`, the current model
-     * will be used.
-     *
-     * @psalm-param ModelClass $modelClass
-     */
-    public function query(ActiveRecordInterface|Closure|null|string $modelClass = null): ActiveQueryInterface
-    {
-        return new ActiveQuery($modelClass ?? $this);
-    }
-
     public function isChanged(): bool
     {
         return !empty($this->newValues());
@@ -564,6 +564,11 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
         $this->related[$name] = $records;
     }
 
+    public static function query(ActiveRecordInterface|Closure|null|string $modelClass = null): ActiveQueryInterface
+    {
+        return new ActiveQuery($modelClass ?? static::class);
+    }
+
     /**
      * Repopulates this active record with the latest data.
      *
@@ -572,7 +577,7 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
      */
     public function refresh(): bool
     {
-        $record = $this->query()->findByPk($this->primaryKeyOldValues());
+        $record = $this->createQuery()->findByPk($this->primaryKeyOldValues());
 
         return $this->refreshInternal($record);
     }
@@ -1050,7 +1055,7 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
         array $link,
         bool $multiple,
     ): ActiveQueryInterface {
-        return $this->query($modelClass)->primaryModel($this)->link($link)->multiple($multiple);
+        return $this->createQuery($modelClass)->primaryModel($this)->link($link)->multiple($multiple);
     }
 
     /**

--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -77,7 +77,7 @@ use function substr;
  * These options can be configured using methods of the same name. For example:
  *
  * ```php
- * $customerQuery = new ActiveQuery(Customer::class);
+ * $customerQuery = Customer::query();
  * $query = $customerQuery->with('orders')->asArray()->all();
  * ```
  *

--- a/src/ActiveQueryInterface.php
+++ b/src/ActiveQueryInterface.php
@@ -62,7 +62,7 @@ interface ActiveQueryInterface extends QueryInterface
      *
      * ```php
      * // Create active query
-     * CustomerQuery = new ActiveQuery(Customer::class);
+     * CustomerQuery = Customer::query();
      * // find customers together with their orders and country
      * CustomerQuery->with('orders', 'country')->all();
      * // find customers together with their orders and the orders' shipping address
@@ -151,11 +151,11 @@ interface ActiveQueryInterface extends QueryInterface
      *
      * ```php
      * // Find all orders that contain books, and eager loading "books".
-     * $orderQuery = new ActiveQuery(Order::class);
+     * $orderQuery = Order::query();
      * $orderQuery->joinWith('books', true, 'INNER JOIN')->all();
      *
      * // Find all orders, eagerly load "books", and sort the orders and books by the book names.
-     * $orderQuery = new ActiveQuery(Order::class, $db);
+     * $orderQuery = Order::query();
      * $orderQuery->joinWith([
      *     'books' => function (ActiveQuery $query) {
      *         $query->orderBy('item.name');
@@ -163,7 +163,7 @@ interface ActiveQueryInterface extends QueryInterface
      * ])->all();
      *
      * // Find all orders that contain books of the category 'Science fiction', using the alias "b" for the book table.
-     * $order = new ActiveQuery(Order::class, $db);
+     * $order = Order::query();
      * $orderQuery->joinWith(['books b'], true, 'INNER JOIN')->where(['b.category' => 'Science fiction'])->all();
      * ```
      * @param array|bool $eagerLoading Whether to eager load the relations specified in `$with`. When this is boolean.
@@ -353,7 +353,7 @@ interface ActiveQueryInterface extends QueryInterface
      * In the examples below, the `id` column is the primary key of the table.
      *
      * ```php
-     * $customerQuery = new ActiveQuery(Customer::class);
+     * $customerQuery = Customer::query();
      *
      * $customer = $customerQuery->findByPk(1); // WHERE id = 1
      * ```
@@ -365,7 +365,7 @@ interface ActiveQueryInterface extends QueryInterface
      * In the examples below, the `id` and `id2` columns are the composite primary key of the table.
      *
      * ```php
-     * $orderItemQuery = new ActiveQuery(OrderItem::class);
+     * $orderItemQuery = OrderItem::query();
      *
      * $orderItem = $orderItemQuery->findByPk([1, 2]); // WHERE id = 1 AND id2 = 2
      * ```
@@ -378,7 +378,7 @@ interface ActiveQueryInterface extends QueryInterface
      * {
      *     $id = (string) $request->getAttribute('id');
      *
-     *     $customerQuery = new ActiveQuery(Customer::class);
+     *     $customerQuery = Customer::query();
      *     $customer = $customerQuery->findByPk($id);
      * }
      * ```

--- a/src/ActiveQueryTrait.php
+++ b/src/ActiveQueryTrait.php
@@ -49,14 +49,12 @@ trait ActiveQueryTrait
      * The following are some usage examples:
      *
      * ```php
-     * // Create active query
-     * CustomerQuery = new ActiveQuery(Customer::class);
      * // find customers together with their orders and country
-     * CustomerQuery->with('orders', 'country')->all();
+     * Customer::query()->with('orders', 'country')->all();
      * // find customers together with their orders and the orders' shipping address
-     * CustomerQuery->with('orders.address')->all();
+     * Customer::query()->with('orders.address')->all();
      * // find customers together with their country and orders of status 1
-     * CustomerQuery->with([
+     * Customer::query()->with([
      *     'orders' => function (ActiveQuery $query) {
      *         $query->andWhere('status = 1');
      *     },
@@ -69,8 +67,8 @@ trait ActiveQueryTrait
      * For example, the following two statements are equivalent:
      *
      * ```php
-     * CustomerQuery->with('orders', 'country')->all();
-     * CustomerQuery->with('orders')->with('country')->all();
+     * Customer::query()->with('orders', 'country')->all();
+     * Customer::query()->with('orders')->with('country')->all();
      * ```
      *
      * @param array|string ...$with A list of relation names or relation definitions.

--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -66,8 +66,7 @@ use const ARRAY_FILTER_USE_KEY;
  * $user->save(); // a new row is inserted into user table
  *
  * // the following will retrieve the user 'CeBe' from the database
- * $userQuery = new ActiveQuery(User::class);
- * $user = $userQuery->where(['name' => 'CeBe'])->one();
+ * $user = User::query()->where(['name' => 'CeBe'])->one();
  *
  * // this will get related records from orders table when relation is defined
  * $orders = $user->orders;

--- a/src/ActiveRecordInterface.php
+++ b/src/ActiveRecordInterface.php
@@ -35,6 +35,15 @@ interface ActiveRecordInterface
     public function columnType(string $propertyName): string;
 
     /**
+     * @param ActiveRecordInterface|Closure|string|null $modelClass The class name of the related record, or an instance
+     * of the related record, or a Closure to create an {@see ActiveRecordInterface} object. If `null`, the current model
+     * will be used.
+     *
+     * @psalm-param ModelClass $modelClass
+     */
+    public function createQuery(ActiveRecordInterface|Closure|null|string $modelClass = null): ActiveQueryInterface;
+
+    /**
      * Returns the database connection used by the Active Record instance.
      */
     public function db(): ConnectionInterface;

--- a/src/ActiveRecordInterface.php
+++ b/src/ActiveRecordInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord;
 
+use Closure;
 use Throwable;
 use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Db\Constant\ColumnType;
@@ -12,6 +13,9 @@ use InvalidArgumentException;
 use Yiisoft\Db\Exception\InvalidCallException;
 use Yiisoft\Db\Exception\InvalidConfigException;
 
+/**
+ * @psalm-import-type ModelClass from ActiveQuery
+ */
 interface ActiveRecordInterface
 {
     /**
@@ -61,8 +65,7 @@ interface ActiveRecordInterface
      * > Warning: If you don't specify any condition, this method will delete **all** rows in the table.
      *
      * ```php
-     * $customerQuery = new ActiveQuery(Customer::class);
-     * $aqClasses = $customerQuery->where('status = 3')->all();
+     * $aqClasses = Customer::query()->where('status = 3')->all();
      * foreach ($aqClasses as $aqClass) {
      *     $aqClass->delete();
      * }
@@ -309,6 +312,11 @@ interface ActiveRecordInterface
     public function populateRelation(string $name, array|self|null $records): void;
 
     /**
+     * @psalm-param ModelClass|null $modelClass
+     */
+    public static function query(ActiveRecordInterface|Closure|null|string $modelClass = null): ActiveQueryInterface;
+
+    /**
      * Returns the primary key name(s) for this AR class.
      *
      * The default implementation will return the primary key(s) as declared in the DB table that's associated with
@@ -422,7 +430,7 @@ interface ActiveRecordInterface
      * For example, to update a customer record:
      *
      * ```php
-     * $customer = (new ActiveQuery(Customer::class))->findByPk(1);
+     * $customer = Customer::query()->findByPk(1);
      * $customer->name = $name;
      * $customer->email = $email;
      * $customer->update();
@@ -471,8 +479,7 @@ interface ActiveRecordInterface
      * > Warning: If you don't specify any condition, this method will update **all** rows in the table.
      *
      * ```php
-     * $customerQuery = new ActiveQuery(Customer::class);
-     * $customers = $customerQuery->where('status = 2')->all();
+     * $customers = Customer::query()->where('status = 2')->all();
      * foreach ($customers as $customer) {
      *     $customer->status = 1;
      *     $customer->update();

--- a/src/ActiveRecordInterface.php
+++ b/src/ActiveRecordInterface.php
@@ -74,9 +74,9 @@ interface ActiveRecordInterface
      * > Warning: If you don't specify any condition, this method will delete **all** rows in the table.
      *
      * ```php
-     * $aqClasses = Customer::query()->where('status = 3')->all();
-     * foreach ($aqClasses as $aqClass) {
-     *     $aqClass->delete();
+     * $customers = Customer::query()->where('status = 3')->all();
+     * foreach ($customers as $customer) {
+     *     $customer->delete();
      * }
      * ```
      *

--- a/src/ActiveRecordInterface.php
+++ b/src/ActiveRecordInterface.php
@@ -314,7 +314,7 @@ interface ActiveRecordInterface
     /**
      * @psalm-param ModelClass|null $modelClass
      */
-    public static function query(ActiveRecordInterface|Closure|null|string $modelClass = null): ActiveQueryInterface;
+    public static function query(self|Closure|null|string $modelClass = null): ActiveQueryInterface;
 
     /**
      * Returns the primary key name(s) for this AR class.

--- a/src/ActiveRelationTrait.php
+++ b/src/ActiveRelationTrait.php
@@ -152,16 +152,14 @@ trait ActiveRelationTrait
      * Let's suppose customer has several orders. If only one order was loaded:
      *
      * ```php
-     * $orderQuery = new ActiveQuery(Order::class);
-     * $orders = $orderQuery->where(['id' => 1])->all();
+     * $orders = Order::query()->where(['id' => 1])->all();
      * $customerOrders = $orders[0]->customer->orders;
      * ```
      *
      * variable `$customerOrders` will contain only one order. If orders was loaded like this:
      *
      * ```php
-     * $orderQuery = new ActiveQuery(Order::class);
-     * $orders = $orderQuery->with('customer')->where(['customer_id' => 1])->all();
+     * $orders = Order::query()->with('customer')->where(['customer_id' => 1])->all();
      * $customerOrders = $orders[0]->customer->orders;
      * ```
      *

--- a/src/Trait/FactoryTrait.php
+++ b/src/Trait/FactoryTrait.php
@@ -33,7 +33,7 @@ trait FactoryTrait
 
     public function createQuery(ActiveRecordInterface|Closure|null|string $modelClass = null): ActiveQueryInterface
     {
-        if (!isset($this->factory) || !$this->factory instanceof Factory) {
+        if (!isset($this->factory)) {
             return parent::createQuery($modelClass);
         }
 

--- a/src/Trait/FactoryTrait.php
+++ b/src/Trait/FactoryTrait.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Yiisoft\ActiveRecord\Trait;
 
 use Closure;
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\ActiveQueryInterface;
 use Yiisoft\ActiveRecord\ActiveRecordInterface;
 use Yiisoft\Factory\Factory;
@@ -16,7 +15,7 @@ use function method_exists;
 /**
  * Trait to add factory support to ActiveRecord.
  *
- * @see AbstractActiveRecord::query()
+ * @see AbstractActiveRecord::createQuery()
  */
 trait FactoryTrait
 {
@@ -32,30 +31,28 @@ trait FactoryTrait
         return $new;
     }
 
-    public function query(ActiveRecordInterface|Closure|null|string $arClass = null): ActiveQueryInterface
+    public function createQuery(ActiveRecordInterface|Closure|null|string $modelClass = null): ActiveQueryInterface
     {
-        if ($arClass === null) {
-            return new ActiveQuery($this);
+        if (!isset($this->factory) || !$this->factory instanceof Factory) {
+            return parent::createQuery($modelClass);
         }
 
-        if (!isset($this->factory)) {
-            return new ActiveQuery($arClass);
-        }
-
-        if (is_string($arClass)) {
-            if (method_exists($arClass, 'withFactory')) {
-                return new ActiveQuery(
-                    fn (): ActiveRecordInterface => $this->factory->create($arClass)->withFactory($this->factory)
+        if (is_string($modelClass)) {
+            if (method_exists($modelClass, 'withFactory')) {
+                return parent::createQuery(
+                    fn (): ActiveRecordInterface => $this->factory->create($modelClass)->withFactory($this->factory)
                 );
             }
 
-            return new ActiveQuery(fn (): ActiveRecordInterface => $this->factory->create($arClass));
+            return parent::createQuery(fn (): ActiveRecordInterface => $this->factory->create($modelClass));
         }
 
-        if ($arClass instanceof ActiveRecordInterface && method_exists($arClass, 'withFactory')) {
-            return new ActiveQuery($arClass->withFactory($this->factory));
+        $modelClass ??= $this;
+
+        if ($modelClass instanceof ActiveRecordInterface && method_exists($modelClass, 'withFactory')) {
+            return parent::createQuery($modelClass->withFactory($this->factory));
         }
 
-        return new ActiveQuery($arClass);
+        return parent::createQuery($modelClass);
     }
 }

--- a/src/Trait/RepositoryTrait.php
+++ b/src/Trait/RepositoryTrait.php
@@ -51,7 +51,7 @@ trait RepositoryTrait
      */
     public static function find(array|string|ExpressionInterface|null $condition = null, array $params = []): ActiveQueryInterface
     {
-        $query = static::instantiate()->query();
+        $query = static::query();
 
         if ($condition === null) {
             return $query;
@@ -160,7 +160,7 @@ trait RepositoryTrait
      */
     public static function findByPk(array|float|int|string $values): array|ActiveRecordInterface|null
     {
-        return static::instantiate()->query()->findByPk($values);
+        return static::query()->findByPk($values);
     }
 
     /**
@@ -203,7 +203,7 @@ trait RepositoryTrait
      */
     public static function findBySql(string $sql, array $params = []): ActiveQueryInterface
     {
-        return static::instantiate()->query()->sql($sql)->params($params);
+        return static::query()->sql($sql)->params($params);
     }
 
     /**
@@ -272,10 +272,5 @@ trait RepositoryTrait
         array $params = [],
     ): ActiveRecordInterface|array|null {
         return static::findOne($condition, $params) ?? throw new NotFoundException('No records found.');
-    }
-
-    protected static function instantiate(): ActiveRecordInterface
-    {
-        return new static();
     }
 }

--- a/tests/ActiveQueryFindTest.php
+++ b/tests/ActiveQueryFindTest.php
@@ -20,7 +20,7 @@ abstract class ActiveQueryFindTest extends TestCase
 {
     public function testFindScalar(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         /** query scalar */
         $customerName = $customerQuery->where(['[[id]]' => 2])->select('[[name]]')->scalar();
@@ -30,7 +30,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindExists(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $this->assertTrue($customerQuery->where(['[[id]]' => 2])->exists());
         $this->assertTrue($customerQuery->setWhere(['[[id]]' => 2])->select('[[name]]')->exists());
@@ -41,7 +41,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindColumn(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $this->assertEquals(
             ['user1', 'user2', 'user3'],
@@ -56,7 +56,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindLazyViaTable(): void
     {
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
 
         $orders = $orderQuery->findByPk(2);
         $this->assertCount(0, $orders->getBooks());
@@ -68,7 +68,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindEagerViaTable(): void
     {
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->with('books')->orderBy('id')->all();
         $this->assertCount(3, $orders);
 
@@ -88,7 +88,7 @@ abstract class ActiveQueryFindTest extends TestCase
         $this->assertEquals(2, $order->getBooks()[0]->get('id'));
 
         /** https://github.com/yiisoft/yii2/issues/1402 */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->with('books')->orderBy('id')->asArray()->all();
         $this->assertCount(3, $orders);
         $this->assertIsArray($orders[0]['orderItems'][0]);
@@ -107,7 +107,7 @@ abstract class ActiveQueryFindTest extends TestCase
      */
     public function testFindCompositeRelationWithJoin(): void
     {
-        $orderItemQuery = new ActiveQuery(OrderItem::class);
+        $orderItemQuery = OrderItem::query();
 
         /** @var $orderItems OrderItem */
         $orderItems = $orderItemQuery->findByPk([1, 1]);
@@ -121,7 +121,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindSimpleRelationWithJoin(): void
     {
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
 
         $orders = $orderQuery->findByPk(1);
         $customerNoJoin = $orders->getCustomer();
@@ -138,7 +138,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFind(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $this->assertInstanceOf(ActiveQueryInterface::class, $customerQuery);
 
         /** find one */
@@ -146,7 +146,7 @@ abstract class ActiveQueryFindTest extends TestCase
         $this->assertInstanceOf(Customer::class, $customer);
 
         /** find all */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->all();
         $this->assertCount(3, $customers);
         $this->assertInstanceOf(Customer::class, $customers[0]);
@@ -154,7 +154,7 @@ abstract class ActiveQueryFindTest extends TestCase
         $this->assertInstanceOf(Customer::class, $customers[2]);
 
         /** find by column */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->where(['name' => 'user2'])->one();
         $this->assertInstanceOf(Customer::class, $customer);
         $this->assertEquals(2, $customer->getId());
@@ -168,7 +168,7 @@ abstract class ActiveQueryFindTest extends TestCase
     public function testFindAsArray(): void
     {
         /** asArray */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->where(['id' => 2])->asArray()->one();
         $this->assertEquals([
             'id' => 2,
@@ -181,7 +181,7 @@ abstract class ActiveQueryFindTest extends TestCase
         ], $customer);
 
         /** find all asArray */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->asArray()->all();
         $this->assertCount(3, $customers);
         $this->assertArrayHasKey('id', $customers[0]);
@@ -203,7 +203,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindIndexBy(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $customers = $customerQuery->indexBy('name')->orderBy('id')->all();
 
@@ -213,7 +213,7 @@ abstract class ActiveQueryFindTest extends TestCase
         $this->assertInstanceOf(Customer::class, $customers['user3']);
 
         /** indexBy callable */
-        $customer = new ActiveQuery(Customer::class);
+        $customer = Customer::query();
 
         $customers = $customer
             ->indexBy(fn (Customer $customer) => $customer->getId() . '-' . $customer->getName())
@@ -228,7 +228,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindIndexByAsArray(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->asArray()->indexBy('name')->all();
         $this->assertCount(3, $customers);
         $this->assertArrayHasKey('id', $customers['user1']);
@@ -248,7 +248,7 @@ abstract class ActiveQueryFindTest extends TestCase
         $this->assertArrayHasKey('status', $customers['user3']);
 
         /** indexBy callable + asArray */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->indexBy(fn ($customer) => $customer['id'] . '-' . $customer['name'])->asArray()->all();
         $this->assertCount(3, $customers);
         $this->assertArrayHasKey('id', $customers['1-user1']);
@@ -270,14 +270,14 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindCount(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $this->assertEquals(3, $customerQuery->count());
         $this->assertEquals(1, $customerQuery->where(['id' => 1])->count());
         $this->assertEquals(2, $customerQuery->setWhere(['id' => [1, 2]])->count());
         $this->assertEquals(2, $customerQuery->setWhere(['id' => [1, 2]])->offset(1)->count());
         $this->assertEquals(2, $customerQuery->setWhere(['id' => [1, 2]])->offset(2)->count());
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $this->assertEquals(3, $customerQuery->limit(1)->count());
         $this->assertEquals(3, $customerQuery->limit(2)->count());
         $this->assertEquals(3, $customerQuery->limit(10)->count());
@@ -287,17 +287,17 @@ abstract class ActiveQueryFindTest extends TestCase
     public function testFindLimit(): void
     {
         /** one */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->orderBy('id')->one();
         $this->assertEquals('user1', $customer->getName());
 
         /** all */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->all();
         $this->assertCount(3, $customers);
 
         /** limit */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->orderBy('id')->limit(1)->all();
         $this->assertCount(1, $customers);
         $this->assertEquals('user1', $customers[0]->getName());
@@ -319,7 +319,7 @@ abstract class ActiveQueryFindTest extends TestCase
         $this->assertCount(0, $customers);
 
         /** offset */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->orderBy('id')->offset(0)->one();
         $this->assertEquals('user1', $customer->getName());
 
@@ -335,7 +335,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindComplexCondition(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $this->assertEquals(
             2,
@@ -372,7 +372,7 @@ abstract class ActiveQueryFindTest extends TestCase
     {
         $this->reloadFixtureAfterTest();
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $customer = $customerQuery->findByPk(2);
         $customer->setName(null);
@@ -385,7 +385,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindEager(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->with('orders')->indexBy('id')->all();
 
         ksort($customers);
@@ -406,7 +406,7 @@ abstract class ActiveQueryFindTest extends TestCase
         $this->assertCount(1, $customer->relatedRecords());
 
         /** multiple with() calls */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->with('customer', 'items')->all();
         $this->assertCount(3, $orders);
         $this->assertTrue($orders[0]->isRelationPopulated('customer'));
@@ -420,7 +420,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindEagerViaRelation(): void
     {
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->with('items')->orderBy('id')->all();
         $this->assertCount(3, $orders);
 
@@ -434,7 +434,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindNestedRelation(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->with('orders', 'orders.items')->indexBy('id')->all();
 
         ksort($customers);
@@ -468,7 +468,7 @@ abstract class ActiveQueryFindTest extends TestCase
      */
     public function testFindEagerViaRelationPreserveOrder(): void
     {
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->with('itemsInOrder1')->orderBy('created_at')->all();
         $this->assertCount(3, $orders);
 
@@ -497,7 +497,7 @@ abstract class ActiveQueryFindTest extends TestCase
     public function testFindEagerViaRelationPreserveOrderB(): void
     {
         /** different order in via table. */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->with('itemsInOrder2')->orderBy('created_at')->all();
         $this->assertCount(3, $orders);
 
@@ -525,7 +525,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindEmptyInCondition(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->where(['id' => [1]])->all();
         $this->assertCount(1, $customers);
 
@@ -541,7 +541,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindEagerIndexBy(): void
     {
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->with('itemsIndexed')->where(['id' => 1])->one();
         $this->assertTrue($order->isRelationPopulated('itemsIndexed'));
 
@@ -562,7 +562,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindLazy(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(2);
         $this->assertFalse($customer->isRelationPopulated('orders'));
 
@@ -586,7 +586,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindLazyVia(): void
     {
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->findByPk(1);
 
         $this->assertEquals(1, $order->getId());
@@ -597,7 +597,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindByPk(): void
     {
-        $customerQuery = new ActiveQuery(new Customer());
+        $customerQuery = Customer::query();
 
         $this->assertEquals(
             $customerQuery->where(['id' => 1])->one(),
@@ -610,7 +610,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindByPkComposite(): void
     {
-        $query = new ActiveQuery(OrderItem::class);
+        $query = OrderItem::query();
 
         $orderItem = $query->findByPk([1, 2]);
 
@@ -626,7 +626,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindByPkWithoutPk(): void
     {
-        $query = new ActiveQuery(Type::class);
+        $query = Type::query();
 
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage('Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Type must have a primary key.');
@@ -636,7 +636,7 @@ abstract class ActiveQueryFindTest extends TestCase
 
     public function testFindByPkWithJoin(): void
     {
-        $query = new ActiveQuery(Order::class);
+        $query = Order::query();
 
         $query->joinWith('items');
 

--- a/tests/ActiveQueryFindTest.php
+++ b/tests/ActiveQueryFindTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests;
 
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\ActiveQueryInterface;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Customer;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\CustomerQuery;

--- a/tests/ActiveQueryTest.php
+++ b/tests/ActiveQueryTest.php
@@ -37,7 +37,7 @@ abstract class ActiveQueryTest extends TestCase
 {
     public function testOptions(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $query = $customerQuery->on(['a' => 'b'])->joinWith('profile');
         $this->assertInstanceOf(Customer::class, $query->getModel());
@@ -49,19 +49,19 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testPrepare(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
         $this->assertInstanceOf(QueryInterface::class, $query->prepare($this->db()->getQueryBuilder()));
     }
 
     public function testPopulateEmptyRows(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
         $this->assertEquals([], $query->populate([]));
     }
 
     public function testPopulateFilledRows(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
         $rows = $query->all();
         $result = $query->populate($rows);
         $this->assertEquals($rows, $result);
@@ -69,7 +69,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testAll(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
 
         foreach ($query->all() as $customer) {
             $this->assertInstanceOf(Customer::class, $customer);
@@ -80,39 +80,39 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testOne(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
         $this->assertInstanceOf(Customer::class, $query->one());
     }
 
     public function testCreateCommand(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
         $this->assertInstanceOf(AbstractCommand::class, $query->createCommand());
     }
 
     public function testQueryScalar(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
         $this->assertEquals('user1', Assert::invokeMethod($query, 'queryScalar', ['name']));
     }
 
     public function testGetJoinWith(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
         $query->joinWith('profile');
         $this->assertEquals([[['profile'], true, 'LEFT JOIN']], $query->getJoinWith());
     }
 
     public function testInnerJoinWith(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
         $query->innerJoinWith('profile');
         $this->assertEquals([[['profile'], true, 'INNER JOIN']], $query->getJoinWith());
     }
 
     public function testBuildJoinWithRemoveDuplicateJoinByTableName(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
         $query->innerJoinWith('orders')->joinWith('orders.orderItems');
         Assert::invokeMethod($query, 'buildJoinWith');
         $this->assertEquals([
@@ -131,13 +131,13 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testGetQueryTableNameFromNotSet(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
         $this->assertEquals(['customer', 'customer'], Assert::invokeMethod($query, 'getTableNameAndAlias'));
     }
 
     public function testGetQueryTableNameFromSet(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
         $query->from(['alias' => 'customer']);
         $this->assertEquals(['customer', 'alias'], Assert::invokeMethod($query, 'getTableNameAndAlias'));
     }
@@ -147,7 +147,7 @@ abstract class ActiveQueryTest extends TestCase
         $on = ['active' => true];
         $params = ['a' => 'b'];
 
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
         $query->onCondition($on, $params);
         $this->assertEquals($on, $query->getOn());
         $this->assertEquals($params, $query->getParams());
@@ -157,7 +157,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         $on = ['active' => true];
         $params = ['a' => 'b'];
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
         $query->andOnCondition($on, $params);
         $this->assertEquals($on, $query->getOn());
         $this->assertEquals($params, $query->getParams());
@@ -169,7 +169,7 @@ abstract class ActiveQueryTest extends TestCase
         $on = ['active' => true];
         $params = ['a' => 'b'];
 
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
 
         $query->on($onOld)->andOnCondition($on, $params);
 
@@ -182,7 +182,7 @@ abstract class ActiveQueryTest extends TestCase
         $on = ['active' => true];
         $params = ['a' => 'b'];
 
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
 
         $query->orOnCondition($on, $params);
 
@@ -196,7 +196,7 @@ abstract class ActiveQueryTest extends TestCase
         $on = ['active' => true];
         $params = ['a' => 'b'];
 
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
 
         $query->on($onOld)->orOnCondition($on, $params);
 
@@ -206,7 +206,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testViaWithEmptyPrimaryModel(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
 
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage('Setting via is only supported for relational queries.');
@@ -218,7 +218,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         $order = new Order();
 
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
 
         $query->primaryModel($order)->viaTable(Profile::class, ['id' => 'item_id']);
 
@@ -228,7 +228,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testAliasNotSet(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
 
         $query->alias('alias');
 
@@ -240,7 +240,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         $aliasOld = ['old'];
 
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
 
         $query->from($aliasOld)->alias('alias');
 
@@ -250,7 +250,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testGetTableNamesNotFilledFrom(): void
     {
-        $query = new ActiveQuery(Profile::class);
+        $query = Profile::query();
         $tableName = Profile::TABLE_NAME;
 
         $this->assertEquals(
@@ -263,7 +263,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testGetTableNamesWontFillFrom(): void
     {
-        $query = new ActiveQuery(Profile::class);
+        $query = Profile::query();
 
         $this->assertSame([], $query->getFrom());
 
@@ -281,7 +281,7 @@ abstract class ActiveQueryTest extends TestCase
     public function testDeeplyNestedTableRelationWith(): void
     {
         /** @var $category Category */
-        $categoriesQuery = new ActiveQuery(Category::class);
+        $categoriesQuery = Category::query();
 
         $categories = $categoriesQuery->with('orders')->indexBy('id')->all();
         $category = $categories[1];
@@ -307,7 +307,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testGetSql(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
 
         $query->sql('SELECT * FROM {{customer}} ORDER BY [[id]] DESC');
 
@@ -316,7 +316,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testCustomColumns(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         /** find custom column */
         if ($this->db()->getDriverName() === 'oci') {
@@ -335,7 +335,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testCallFind(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         /** find count, sum, average, min, max, scalar */
         $this->assertEquals(3, $customerQuery->count());
@@ -349,7 +349,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testDeeplyNestedTableRelation(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $customers = $customerQuery->findByPk(1);
 
@@ -370,7 +370,7 @@ abstract class ActiveQueryTest extends TestCase
      */
     public function testDeeplyNestedTableRelation2(): void
     {
-        $categoryQuery = new ActiveQuery(Category::class);
+        $categoryQuery = Category::query();
 
         $categories = $categoryQuery->where(['id' => 1])->one();
         $this->assertNotNull($categories);
@@ -396,7 +396,7 @@ abstract class ActiveQueryTest extends TestCase
     public function testJoinWith(): void
     {
         /** left join and eager loading */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->joinWith('customer')->orderBy('customer.id DESC, order.id')->all();
         $this->assertCount(3, $orders);
         $this->assertEquals(2, $orders[0]->getId());
@@ -407,7 +407,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertTrue($orders[2]->isRelationPopulated('customer'));
 
         /** inner join filtering and eager loading */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->innerJoinWith(
             [
                 'customer' => function ($query) {
@@ -422,7 +422,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertTrue($orders[1]->isRelationPopulated('customer'));
 
         /** inner join filtering, eager loading, conditions on both primary and relation */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->innerJoinWith(
             [
                 'customer' => function ($query) {
@@ -435,7 +435,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertTrue($orders[0]->isRelationPopulated('customer'));
 
         /** inner join filtering without eager loading */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->innerJoinWith(
             [
                 'customer' => static function ($query) {
@@ -451,7 +451,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertFalse($orders[1]->isRelationPopulated('customer'));
 
         /** inner join filtering without eager loading, conditions on both primary and relation */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->innerJoinWith(
             [
                 'customer' => static function ($query) {
@@ -465,7 +465,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertFalse($orders[0]->isRelationPopulated('customer'));
 
         /** join with via-relation */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->innerJoinWith('books')->orderBy('order.id')->all();
         $this->assertCount(2, $orders);
         $this->assertCount(2, $orders[0]->getBooks());
@@ -476,7 +476,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertTrue($orders[1]->isRelationPopulated('books'));
 
         /** join with sub-relation */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->innerJoinWith(
             [
                 'items' => function ($q) {
@@ -495,7 +495,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertTrue($orders[0]->getItems()[0]->isRelationPopulated('category'));
 
         /** join with table alias */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->joinWith(
             [
                 'customer' => function ($q) {
@@ -512,7 +512,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertTrue($orders[2]->isRelationPopulated('customer'));
 
         /** join with table alias */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->joinWith('customer as c')->orderBy('c.id DESC, order.id')->all();
         $this->assertCount(3, $orders);
         $this->assertEquals(2, $orders[0]->getId());
@@ -523,7 +523,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertTrue($orders[2]->isRelationPopulated('customer'));
 
         /** join with table alias sub-relation */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->innerJoinWith(
             [
                 'items as t' => function ($q) {
@@ -542,7 +542,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertTrue($orders[0]->getItems()[0]->isRelationPopulated('category'));
 
         /** join with ON condition */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->joinWith('books2')->orderBy('order.id')->all();
         $this->assertCount(3, $orders);
         $this->assertCount(2, $orders[0]->getBooks2());
@@ -556,20 +556,20 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertTrue($orders[2]->isRelationPopulated('books2'));
 
         /** lazy loading with ON condition */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->findByPk(1);
         $this->assertCount(2, $order->getBooks2());
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->findByPk(2);
         $this->assertCount(0, $order->getBooks2());
 
-        $order = new ActiveQuery(Order::class);
+        $order = Order::query();
         $order = $order->findByPk(3);
         $this->assertCount(1, $order->getBooks2());
 
         /** eager loading with ON condition */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->with('books2')->all();
         $this->assertCount(3, $orders);
         $this->assertCount(2, $orders[0]->getBooks2());
@@ -583,7 +583,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertTrue($orders[2]->isRelationPopulated('books2'));
 
         /** join with count and query */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $query = $orderQuery->joinWith('customer');
         $count = $query->count();
         $this->assertEquals(3, $count);
@@ -592,7 +592,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertCount(3, $orders);
 
         /** {@see https://github.com/yiisoft/yii2/issues/2880} */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $query = $orderQuery->findByPk(1);
         $customer = $query->getCustomerQuery()->joinWith(
             [
@@ -603,7 +603,7 @@ abstract class ActiveQueryTest extends TestCase
         )->one();
         $this->assertEquals(1, $customer->getId());
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->joinWith(
             [
                 'items' => static function ($q) {
@@ -613,7 +613,7 @@ abstract class ActiveQueryTest extends TestCase
         )->orderBy('order.id')->one();
 
         /** join with sub-relation called inside Closure */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->joinWith(
             [
                 'items' => static function ($q) {
@@ -684,7 +684,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         $this->reloadFixtureAfterTest();
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
 
         $this->db()->getQueryBuilder()->setSeparator("\n");
 
@@ -720,7 +720,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         $orders = [];
         /** left join and eager loading */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $query = $orderQuery->joinWith(['customer c']);
 
         if ($aliasMethod === 'explicit') {
@@ -742,7 +742,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertTrue($orders[2]->isRelationPopulated('customer'));
 
         /** inner join filtering and eager loading */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $query = $orderQuery->innerJoinWith(['customer c']);
 
         if ($aliasMethod === 'explicit') {
@@ -762,7 +762,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertTrue($orders[1]->isRelationPopulated('customer'));
 
         /** inner join filtering without eager loading */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $query = $orderQuery->innerJoinWith(['customer c'], false);
 
         if ($aliasMethod === 'explicit') {
@@ -782,7 +782,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertFalse($orders[1]->isRelationPopulated('customer'));
 
         /** join with via-relation */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $query = $orderQuery->innerJoinWith(['books b']);
 
         if ($aliasMethod === 'explicit') {
@@ -808,7 +808,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertTrue($orders[1]->isRelationPopulated('books'));
 
         /** joining sub relations */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $query = $orderQuery->innerJoinWith(
             [
                 'items i' => static function ($q) use ($aliasMethod) {
@@ -853,7 +853,7 @@ abstract class ActiveQueryTest extends TestCase
         if ($aliasMethod === 'explicit' || $aliasMethod === 'querysyntax') {
             $relationName = 'books' . ucfirst($aliasMethod);
 
-            $orderQuery = new ActiveQuery(Order::class);
+            $orderQuery = Order::query();
             $orders = $orderQuery->joinWith(["$relationName b"])->orderBy('order.id')->all();
 
             $this->assertCount(3, $orders);
@@ -872,7 +872,7 @@ abstract class ActiveQueryTest extends TestCase
         if ($aliasMethod === 'explicit' || $aliasMethod === 'querysyntax') {
             $relationName = 'books' . ucfirst($aliasMethod) . 'A';
 
-            $orderQuery = new ActiveQuery(Order::class);
+            $orderQuery = Order::query();
             $orders = $orderQuery->joinWith([$relationName])->orderBy('order.id')->all();
 
             $this->assertCount(3, $orders);
@@ -888,7 +888,7 @@ abstract class ActiveQueryTest extends TestCase
         }
 
         /** join with count and query */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $query = $orderQuery->joinWith(['customer c']);
 
         if ($aliasMethod === 'explicit') {
@@ -905,7 +905,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertCount(3, $orders);
 
         /** relational query */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->findByPk(1);
 
         $customerQuery = $order->getCustomerQuery()->innerJoinWith(['orders o'], false);
@@ -922,7 +922,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertNotNull($customer);
 
         /** join with sub-relation called inside Closure */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->joinWith(
             [
                 'items' => static function ($q) use ($aliasMethod) {
@@ -958,7 +958,7 @@ abstract class ActiveQueryTest extends TestCase
          * join with the same table but different aliases alias is defined in the relation definition without eager
          * loading
          */
-        $query = new ActiveQuery(Order::class);
+        $query = Order::query();
         $query->joinWith('bookItems', false)->joinWith('movieItems', false)->where(['movies.name' => 'Toy Story']);
         $orders = $query->all();
         $this->assertCount(
@@ -971,7 +971,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertFalse($orders[0]->isRelationPopulated('movieItems'));
 
         /** with eager loading */
-        $query = new ActiveQuery(Order::class);
+        $query = Order::query();
         $query->joinWith('bookItems', true)->joinWith('movieItems', true)->where(['movies.name' => 'Toy Story']);
         $orders = $query->all();
         $this->assertCount(
@@ -989,7 +989,7 @@ abstract class ActiveQueryTest extends TestCase
          * join with the same table but different aliases alias is defined in the call to joinWith() without eager
          * loading
          */
-        $query = new ActiveQuery(Order::class);
+        $query = Order::query();
         $query
             ->joinWith(
                 [
@@ -1016,7 +1016,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertFalse($orders[0]->isRelationPopulated('itemsIndexed'));
 
         /** with eager loading, only for one relation as it would be overwritten otherwise. */
-        $query = new ActiveQuery(Order::class);
+        $query = Order::query();
         $query
             ->joinWith(
                 [
@@ -1041,7 +1041,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertTrue($orders[0]->isRelationPopulated('itemsIndexed'));
 
         /** with eager loading, and the other relation */
-        $query = new ActiveQuery(Order::class);
+        $query = Order::query();
         $query
             ->joinWith(
                 [
@@ -1073,7 +1073,7 @@ abstract class ActiveQueryTest extends TestCase
     public function testJoinWithDuplicateSimple(): void
     {
         /** left join and eager loading */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
 
         $orders = $orderQuery
             ->innerJoinWith('customer')
@@ -1096,7 +1096,7 @@ abstract class ActiveQueryTest extends TestCase
     public function testJoinWithDuplicateCallbackFiltering(): void
     {
         /** inner join filtering and eager loading */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
 
         $orders = $orderQuery
             ->innerJoinWith('customer')
@@ -1119,7 +1119,7 @@ abstract class ActiveQueryTest extends TestCase
     public function testJoinWithDuplicateCallbackFilteringConditionsOnPrimary(): void
     {
         /** inner join filtering, eager loading, conditions on both primary and relation */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
 
         $orders = $orderQuery
             ->innerJoinWith('customer')
@@ -1140,7 +1140,7 @@ abstract class ActiveQueryTest extends TestCase
     public function testJoinWithDuplicateWithSubRelation(): void
     {
         /** join with sub-relation */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
 
         $orders = $orderQuery
             ->innerJoinWith('items')
@@ -1164,7 +1164,7 @@ abstract class ActiveQueryTest extends TestCase
     public function testJoinWithDuplicateTableAlias1(): void
     {
         /** join with table alias */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
 
         $orders = $orderQuery
             ->innerJoinWith('customer')
@@ -1189,7 +1189,7 @@ abstract class ActiveQueryTest extends TestCase
     public function testJoinWithDuplicateTableAlias2(): void
     {
         /** join with table alias */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
 
         $orders = $orderQuery
             ->innerJoinWith('customer')
@@ -1212,7 +1212,7 @@ abstract class ActiveQueryTest extends TestCase
     public function testJoinWithDuplicateTableAliasSubRelation(): void
     {
         /** join with table alias sub-relation */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
 
         $orders = $orderQuery
             ->innerJoinWith([
@@ -1240,7 +1240,7 @@ abstract class ActiveQueryTest extends TestCase
     public function testJoinWithDuplicateSubRelationCalledInsideClosure(): void
     {
         /** join with sub-relation called inside Closure */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
 
         $orders = $orderQuery
             ->innerJoinWith('items')
@@ -1269,7 +1269,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         $order = new Order();
 
-        $query = new ActiveQuery(Order::class);
+        $query = Order::query();
         $this->assertSame([], $query->getFrom());
 
         $query->alias('o');
@@ -1285,7 +1285,7 @@ abstract class ActiveQueryTest extends TestCase
     public function testInverseOf(): void
     {
         /** eager loading: find one and all */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->with('orders2')->where(['id' => 1])->one();
         $this->assertSame($customer->getOrders2()[0]->getCustomer2(), $customer);
 
@@ -1294,7 +1294,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertSame($customers[0]->getOrders2()[0]->getCustomer2(), $customers[0]);
 
         /** lazy loading */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(2);
         $orders = $customer->getOrders2();
         $this->assertCount(2, $orders);
@@ -1302,7 +1302,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertSame($customer->getOrders2()[1]->getCustomer2(), $customer);
 
         /** ad-hoc lazy loading */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(2);
         $orders = $customer->getOrders2Query()->all();
         $this->assertCount(2, $orders);
@@ -1318,42 +1318,42 @@ abstract class ActiveQueryTest extends TestCase
         );
 
         /** the other way around */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->with('orders2')->where(['id' => 1])->asArray()->one();
         $this->assertSame($customer['orders2'][0]['customer2']['id'], $customer['id']);
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->with('orders2')->where(['id' => [1, 3]])->asArray()->all();
         $this->assertSame($customer['orders2'][0]['customer2']['id'], $customers[0]['id']);
         $this->assertEmpty($customers[1]['orders2']);
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->with('customer2')->where(['id' => 1])->all();
         $this->assertSame($orders[0]->getCustomer2()->getOrders2(), [$orders[0]]);
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->with('customer2')->where(['id' => 1])->one();
         $this->assertSame($order->getCustomer2()->getOrders2(), [$order]);
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->with('customer2')->where(['id' => 1])->asArray()->all();
         $this->assertSame($orders[0]['customer2']['orders2'][0]['id'], $orders[0]['id']);
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->with('customer2')->where(['id' => 1])->asArray()->one();
         $this->assertSame($order['customer2']['orders2'][0]['id'], $orders[0]['id']);
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->with('customer2')->where(['id' => [1, 3]])->all();
         $this->assertSame($orders[0]->getCustomer2()->getOrders2(), [$orders[0]]);
         $this->assertSame($orders[1]->getCustomer2()->getOrders2(), [$orders[1]]);
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->with('customer2')->where(['id' => [2, 3]])->orderBy('id')->all();
         $this->assertSame($orders[0]->getCustomer2()->getOrders2(), $orders);
         $this->assertSame($orders[1]->getCustomer2()->getOrders2(), $orders);
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->with('customer2')->where(['id' => [2, 3]])->orderBy('id')->asArray()->all();
         $this->assertSame($orders[0]['customer2']['orders2'][0]['id'], $orders[0]['id']);
         $this->assertSame($orders[0]['customer2']['orders2'][1]['id'], $orders[1]['id']);
@@ -1366,14 +1366,14 @@ abstract class ActiveQueryTest extends TestCase
         $this->reloadFixtureAfterTest();
 
         /** via table with delete. */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->findByPk(1);
         $this->assertCount(2, $order->getBooksViaTable());
 
-        $orderItemQuery = new ActiveQuery(OrderItem::class);
+        $orderItemQuery = OrderItem::query();
         $orderItemCount = $orderItemQuery->count();
 
-        $itemQuery = new ActiveQuery(Item::class);
+        $itemQuery = Item::query();
         $this->assertEquals(5, $itemQuery->count());
 
         $order->unlinkAll('booksViaTable', true);
@@ -1384,7 +1384,7 @@ abstract class ActiveQueryTest extends TestCase
         /** via table without delete */
         $this->assertCount(2, $order->getBooksWithNullFKViaTable());
 
-        $orderItemsWithNullFKQuery = new ActiveQuery(OrderItemWithNullFK::class);
+        $orderItemsWithNullFKQuery = OrderItemWithNullFK::query();
         $orderItemCount = $orderItemsWithNullFKQuery->count();
         $this->assertEquals(5, $itemQuery->count());
 
@@ -1394,7 +1394,7 @@ abstract class ActiveQueryTest extends TestCase
             ['AND', ['item_id' => [1, 2]], ['order_id' => null]]
         )->count());
 
-        $orderItemsWithNullFKQuery = new ActiveQuery(OrderItemWithNullFK::class);
+        $orderItemsWithNullFKQuery = OrderItemWithNullFK::query();
         $this->assertEquals($orderItemCount, $orderItemsWithNullFKQuery->count());
         $this->assertEquals(5, $itemQuery->count());
     }
@@ -1404,7 +1404,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->reloadFixtureAfterTest();
 
         /** {@see https://github.com/yiisoft/yii2/issues/4938} */
-        $categoryQuery = new ActiveQuery(Category::class);
+        $categoryQuery = Category::query();
         $category = $categoryQuery->findByPk(2);
         $this->assertInstanceOf(Category::class, $category);
         $this->assertEquals(3, $category->getItemsQuery()->count());
@@ -1412,14 +1412,14 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertEquals(1, $category->getLimitedItemsQuery()->distinct(true)->count());
 
         /** {@see https://github.com/yiisoft/yii2/issues/3197} */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->with('orderItems')->orderBy('id')->all();
         $this->assertCount(3, $orders);
         $this->assertCount(2, $orders[0]->getOrderItems());
         $this->assertCount(3, $orders[1]->getOrderItems());
         $this->assertCount(1, $orders[2]->getOrderItems());
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->with(
             [
                 'orderItems' => static function ($q) {
@@ -1445,7 +1445,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testViaTableWithStringColumn(): void
     {
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->with('orderItemsByName')->orderBy('id')->all();
 
         $this->assertCount(3, $orders);
@@ -1471,7 +1471,7 @@ abstract class ActiveQueryTest extends TestCase
     public function testPopulateWithoutPk(): void
     {
         /** tests with single pk asArray */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $aggregation = $customerQuery
             ->select(['{{customer}}.[[status]]', 'SUM({{order}}.[[total]]) AS [[sumtotal]]'])
             ->joinWith('ordersPlain', false)
@@ -1494,7 +1494,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertEquals($expected, $aggregation);
 
         // tests with single pk asArray with eager loading
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $aggregation = $customerQuery
             ->select(['{{customer}}.[[status]]', 'SUM({{order}}.[[total]]) AS [[sumtotal]]'])
             ->joinWith('ordersPlain')
@@ -1518,7 +1518,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertEquals($expected, $aggregation);
 
         /** tests with single pk with Models */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $aggregation = $customerQuery
             ->select(['{{customer}}.[[status]]', 'SUM({{order}}.[[total]]) AS [[sumTotal]]'])
             ->joinWith('ordersPlain', false)
@@ -1538,7 +1538,7 @@ abstract class ActiveQueryTest extends TestCase
         }
 
         /** tests with composite pk asArray */
-        $orderItemQuery = new ActiveQuery(OrderItem::class);
+        $orderItemQuery = OrderItem::query();
         $aggregation = $orderItemQuery
             ->select(['[[order_id]]', 'SUM([[subtotal]]) AS [[subtotal]]'])
             ->joinWith('order', false)
@@ -1564,7 +1564,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertEquals($expected, $aggregation);
 
         /** tests with composite pk with Models */
-        $orderItemQuery = new ActiveQuery(OrderItem::class);
+        $orderItemQuery = OrderItem::query();
         $aggregation = $orderItemQuery
             ->select(['[[order_id]]', 'SUM([[subtotal]]) AS [[subtotal]]'])
             ->joinWith('order', false)
@@ -1590,7 +1590,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         $this->reloadFixtureAfterTest();
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->with('orderItems2')->where(['id' => 1])->one();
 
         $orderItem = new OrderItem();
@@ -1606,7 +1606,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testEmulateExecution(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $this->assertGreaterThan(0, $customerQuery->count());
         $this->assertSame([], $customerQuery->emulateExecution()->all());
@@ -1629,11 +1629,11 @@ abstract class ActiveQueryTest extends TestCase
         $this->reloadFixtureAfterTest();
 
         /** Ensure there are three items with category_id = 2 in the Items table */
-        $itemQuery = new ActiveQuery(Item::class);
+        $itemQuery = Item::query();
         $itemsCount = $itemQuery->where(['category_id' => 2])->count();
         $this->assertEquals(3, $itemsCount);
 
-        $categoryQuery = new ActiveQuery(Category::class);
+        $categoryQuery = Category::query();
         $categoryQuery = $categoryQuery->with('limitedItems')->where(['id' => 2]);
 
         /**
@@ -1661,11 +1661,11 @@ abstract class ActiveQueryTest extends TestCase
         $this->reloadFixtureAfterTest();
 
         /** Ensure there are three items with category_id = 2 in the Items table */
-        $itemQuery = new ActiveQuery(Item::class);
+        $itemQuery = Item::query();
         $itemsCount = $itemQuery->where(['category_id' => 2])->count();
         $this->assertEquals(3, $itemsCount);
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orderQuery = $orderQuery->with('limitedItems')->where(['id' => 2]);
 
         /**
@@ -1689,7 +1689,7 @@ abstract class ActiveQueryTest extends TestCase
      */
     public function testIndexByAfterLoadingRelations(): void
     {
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orderQuery->with('customer')->indexBy(function (Order $order) {
             $this->assertTrue($order->isRelationPopulated('customer'));
             $this->assertNotEmpty($order->getCustomer()?->getId());
@@ -1706,7 +1706,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testExtraFields(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $query = $customerQuery->with('orders2')->where(['id' => 1])->one();
         $this->assertCount(1, $query->relatedRecords());
@@ -1750,7 +1750,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertSame($orderTableName, $order->tableName());
         $this->assertSame($orderItemTableName, $orderItem->tableName());
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->findByPk(1);
         $itemsSQL = $order->getOrderItemsQuery()->createCommand()->getRawSql();
         $expectedSQL = DbHelper::replaceQuotes(
@@ -1774,7 +1774,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testOutdatedRelationsAreResetForExistingRecords(): void
     {
-        $orderItemQuery = new ActiveQuery(OrderItem::class);
+        $orderItemQuery = OrderItem::query();
         $orderItems = $orderItemQuery->findByPk([1, 1]);
         $this->assertEquals(1, $orderItems->getOrder()->getId());
         $this->assertEquals(1, $orderItems->getItem()->getId());
@@ -1794,7 +1794,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testOutdatedCompositeKeyRelationsAreReset(): void
     {
-        $dossierQuery = new ActiveQuery(Dossier::class);
+        $dossierQuery = Dossier::query();
 
         $dossiers = $dossierQuery->where(['department_id' => 1, 'employee_id' => 1])->one();
         $this->assertEquals('John Doe', $dossiers->getEmployee()->getFullName());
@@ -1822,7 +1822,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testOutdatedViaTableRelationsAreReset(): void
     {
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
 
         $orders = $orderQuery->findByPk(1);
         $orderItemIds = ArArrayHelper::getColumn($orders->getItems(), 'id');
@@ -1847,7 +1847,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testInverseOfDynamic(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $customer = $customerQuery->findByPk(1);
 
@@ -1880,7 +1880,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         $this->reloadFixtureAfterTest();
 
-        $documentQuery = new ActiveQuery(Document::class);
+        $documentQuery = Document::query();
         $record = $documentQuery->findByPk(1);
 
         $record->content = 'New Content';
@@ -1899,7 +1899,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         $this->reloadFixtureAfterTest();
 
-        $documentQuery = new ActiveQuery(Document::class);
+        $documentQuery = Document::query();
         $document = $documentQuery->findByPk(1);
 
         $this->assertSame(0, $document->version);
@@ -1914,7 +1914,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         $this->reloadFixtureAfterTest();
 
-        $documentQuery = new ActiveQuery(Document::class);
+        $documentQuery = Document::query();
         $document = $documentQuery->findByPk(1);
 
         $this->assertSame(0, $document->version);
@@ -1928,11 +1928,11 @@ abstract class ActiveQueryTest extends TestCase
     /** @link https://github.com/yiisoft/yii2/issues/9006 */
     public function testBit(): void
     {
-        $bitValueQuery = new ActiveQuery(BitValues::class);
+        $bitValueQuery = BitValues::query();
         $falseBit = $bitValueQuery->findByPk(1);
         $this->assertFalse($falseBit->val);
 
-        $bitValueQuery = new ActiveQuery(BitValues::class);
+        $bitValueQuery = BitValues::query();
         $trueBit = $bitValueQuery->findByPk(2);
         $this->assertTrue($trueBit->val);
     }
@@ -1941,7 +1941,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         $this->reloadFixtureAfterTest();
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->findByPk(1);
         $newTotal = 978;
         $this->assertSame(1, $order->update(['total' => $newTotal]));
@@ -1991,7 +1991,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testCustomARRelation(): void
     {
-        $orderItem = new ActiveQuery(OrderItem::class);
+        $orderItem = OrderItem::query();
 
         $orderItem = $orderItem->findByPk([1, 1]);
 
@@ -2010,7 +2010,7 @@ abstract class ActiveQueryTest extends TestCase
             'profile_id' => 1,
         ];
 
-        $customer = new ActiveQuery(Customer::class);
+        $customer = Customer::query();
 
         $values = $customer->findByPk(1)->propertyValues();
 
@@ -2019,7 +2019,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testPropertyValuesOnly(): void
     {
-        $customer = new ActiveQuery(Customer::class);
+        $customer = Customer::query();
 
         $values = $customer->findByPk(1)->propertyValues(['id', 'email', 'name']);
 
@@ -2028,7 +2028,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testPropertyValuesExcept(): void
     {
-        $customer = new ActiveQuery(Customer::class);
+        $customer = Customer::query();
 
         $values = $customer->findByPk(1)->propertyValues(null, ['status', 'bool_status', 'profile_id']);
 
@@ -2040,7 +2040,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testGetOldValue(): void
     {
-        $customer = new ActiveQuery(Customer::class);
+        $customer = Customer::query();
 
         $query = $customer->findByPk(1);
         $this->assertEquals('user1', $query->oldValue('name'));
@@ -2064,7 +2064,7 @@ abstract class ActiveQueryTest extends TestCase
             'profile_id' => 1,
         ];
 
-        $customer = new ActiveQuery(Customer::class);
+        $customer = Customer::query();
 
         $query = $customer->findByPk(1);
         $this->assertEquals($expectedValues, $query->propertyValues());
@@ -2082,7 +2082,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testIsPropertyChanged(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
 
         $customer = $query->findByPk(1);
         $this->assertTrue($customer->get('bool_status'));
@@ -2126,7 +2126,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         self::markTestSkipped('There is no check for access to an unknown property.');
 
-        $customer = new ActiveQuery(Customer::class);
+        $customer = Customer::query();
 
         $query = $customer->findByPk(1);
 
@@ -2139,7 +2139,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         self::markTestSkipped('There is no check for access to an unknown property.');
 
-        $customer = new ActiveQuery(Customer::class);
+        $customer = Customer::query();
 
         $query = $customer->findByPk(2);
 
@@ -2152,7 +2152,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testGetRelationInvalidArgumentException(): void
     {
-        $customer = new ActiveQuery(Customer::class);
+        $customer = Customer::query();
 
         $query = $customer->findByPk(1);
 
@@ -2168,7 +2168,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         self::markTestSkipped('The same as test testGetRelationInvalidArgumentException()');
 
-        $customer = new ActiveQuery(Customer::class);
+        $customer = Customer::query();
 
         $query = $customer->findByPk(1);
 
@@ -2184,7 +2184,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         self::markTestSkipped('The same as test testGetRelationInvalidArgumentException()');
 
-        $customer = new ActiveQuery(Customer::class);
+        $customer = Customer::query();
 
         $query = $customer->findByPk(1);
 
@@ -2198,7 +2198,7 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testExists(): void
     {
-        $customer = new ActiveQuery(Customer::class);
+        $customer = Customer::query();
 
         $this->assertTrue($customer->where(['id' => 2])->exists());
         $this->assertFalse($customer->setWhere(['id' => 5])->exists());
@@ -2214,30 +2214,30 @@ abstract class ActiveQueryTest extends TestCase
         $this->reloadFixtureAfterTest();
 
         /** has many without delete */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(2);
         $this->assertCount(2, $customer->getOrdersWithNullFK());
         $customer->unlink('ordersWithNullFK', $customer->getOrdersWithNullFK()[1], false);
         $this->assertCount(1, $customer->getOrdersWithNullFK());
 
-        $orderWithNullFKQuery = new ActiveQuery(OrderWithNullFK::class);
+        $orderWithNullFKQuery = OrderWithNullFK::query();
         $orderWithNullFK = $orderWithNullFKQuery->findByPk(3);
         $this->assertEquals(3, $orderWithNullFK->getId());
         $this->assertNull($orderWithNullFK->getCustomerId());
 
         /** has many with delete */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(2);
         $this->assertCount(2, $customer->getOrders());
 
         $customer->unlink('orders', $customer->getOrders()[1], true);
         $this->assertCount(1, $customer->getOrders());
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $this->assertNull($orderQuery->findByPk(3));
 
         /** via model with delete */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->findByPk(2);
         $this->assertCount(3, $order->getItems());
         $this->assertCount(3, $order->getOrderItems());
@@ -2261,12 +2261,12 @@ abstract class ActiveQueryTest extends TestCase
         $orderWithNullFKInstance = new OrderWithNullFK();
         $orderWithNullFKInstance->updateAll(['customer_id' => 1]);
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(1);
         $this->assertCount(3, $customer->getOrdersWithNullFK());
         $this->assertCount(1, $customer->getExpensiveOrdersWithNullFK());
 
-        $orderWithNullFKQuery = new ActiveQuery(OrderWithNullFK::class);
+        $orderWithNullFKQuery = OrderWithNullFK::query();
         $this->assertEquals(3, $orderWithNullFKQuery->count());
 
         $customer->unlinkAll('expensiveOrdersWithNullFK');
@@ -2287,12 +2287,12 @@ abstract class ActiveQueryTest extends TestCase
         $orderInstance = new Order();
         $orderInstance->updateAll(['customer_id' => 1]);
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(1);
         $this->assertCount(3, $customer->getOrders());
         $this->assertCount(1, $customer->getExpensiveOrders());
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $this->assertEquals(3, $orderQuery->count());
 
         $customer->unlinkAll('expensiveOrders', true);
@@ -2309,7 +2309,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         $this->reloadFixtureAfterTest();
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(2);
         $this->assertInstanceOf(Customer::class, $customer);
         $this->assertEquals('user2', $customer->get('name'));
@@ -2325,14 +2325,14 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertEquals('user2x', $customer2->get('name'));
 
         /** no update */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(1);
 
         $customer->set('name', 'user1');
         $this->assertEquals(0, $customer->update());
 
         /** updateAll */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(3);
         $this->assertEquals('user3', $customer->get('name'));
 
@@ -2355,7 +2355,7 @@ abstract class ActiveQueryTest extends TestCase
 
         /** updateCounters */
         $pk = [2, 4];
-        $orderItemQuery = new ActiveQuery(OrderItem::class);
+        $orderItemQuery = OrderItem::query();
         $orderItem = $orderItemQuery->findByPk($pk);
         $this->assertEquals(1, $orderItem->getQuantity());
 
@@ -2368,7 +2368,7 @@ abstract class ActiveQueryTest extends TestCase
 
         /** updateAllCounters */
         $pk = [1, 2];
-        $orderItemQuery = new ActiveQuery(OrderItem::class);
+        $orderItemQuery = OrderItem::query();
         $orderItem = $orderItemQuery->findByPk($pk);
         $this->assertEquals(2, $orderItem->getQuantity());
 
@@ -2386,7 +2386,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->reloadFixtureAfterTest();
 
         /** delete */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(2);
         $this->assertInstanceOf(Customer::class, $customer);
         $this->assertEquals('user2', $customer->getName());
@@ -2397,7 +2397,7 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertNull($customer);
 
         /** deleteAll */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->all();
         $this->assertCount(2, $customers);
 
@@ -2417,7 +2417,7 @@ abstract class ActiveQueryTest extends TestCase
      */
     public function testViaWithCallable(): void
     {
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
 
         $order = $orderQuery->findByPk(2);
 
@@ -2435,7 +2435,7 @@ abstract class ActiveQueryTest extends TestCase
     {
         $this->reloadFixtureAfterTest();
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(2);
         $this->assertCount(2, $customer->getOrders());
 
@@ -2453,7 +2453,7 @@ abstract class ActiveQueryTest extends TestCase
         $order->setCreatedAt(time());
         $this->assertTrue($order->isNewRecord());
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(1);
         $this->assertNull($order->getCustomer());
 
@@ -2463,22 +2463,22 @@ abstract class ActiveQueryTest extends TestCase
         $this->assertEquals(1, $order->getCustomer()->primaryKeyValue());
 
         /** via model */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->findByPk(1);
         $this->assertCount(2, $order->getItems());
         $this->assertCount(2, $order->getOrderItems());
 
-        $orderItemQuery = new ActiveQuery(OrderItem::class);
+        $orderItemQuery = OrderItem::query();
         $orderItem = $orderItemQuery->findByPk([1, 3]);
         $this->assertNull($orderItem);
 
-        $itemQuery = new ActiveQuery(Item::class);
+        $itemQuery = Item::query();
         $item = $itemQuery->findByPk(3);
         $order->link('items', $item, ['quantity' => 10, 'subtotal' => 100]);
         $this->assertCount(3, $order->getItems());
         $this->assertCount(3, $order->getOrderItems());
 
-        $orderItemQuery = new ActiveQuery(OrderItem::class);
+        $orderItemQuery = OrderItem::query();
         $orderItem = $orderItemQuery->findByPk([1, 3]);
         $this->assertInstanceOf(OrderItem::class, $orderItem);
         $this->assertEquals(10, $orderItem->getQuantity());
@@ -2487,21 +2487,21 @@ abstract class ActiveQueryTest extends TestCase
 
     public function testEqual(): void
     {
-        $customerA = (new ActiveQuery(Customer::class))->findByPk(1);
-        $customerB = (new ActiveQuery(Customer::class))->findByPk(2);
+        $customerA = Customer::query()->findByPk(1);
+        $customerB = Customer::query()->findByPk(2);
         $this->assertFalse($customerA->equals($customerB));
 
-        $customerB = (new ActiveQuery(Customer::class))->findByPk(1);
+        $customerB = Customer::query()->findByPk(1);
         $this->assertTrue($customerA->equals($customerB));
 
-        $customerA = (new ActiveQuery(Customer::class))->findByPk(1);
-        $customerB = (new ActiveQuery(Item::class))->findByPk(1);
+        $customerA = Customer::query()->findByPk(1);
+        $customerB = Item::query()->findByPk(1);
         $this->assertFalse($customerA->equals($customerB));
     }
 
     public function testArClassAsString(): void
     {
-        $query = new ActiveQuery(Customer::class);
+        $query = Customer::query();
 
         $this->assertInstanceOf(Customer::class, $query->getModel());
     }
@@ -2509,7 +2509,7 @@ abstract class ActiveQueryTest extends TestCase
     public function testArClassAsInstance(): void
     {
         $customer = new Customer();
-        $query = new ActiveQuery($customer);
+        $query = $customer->createQuery();
 
         $this->assertInstanceOf(Customer::class, $query->getModel());
     }

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -202,7 +202,7 @@ abstract class ActiveRecordTest extends TestCase
         $arClass->save();
 
         /** @var $model Type */
-        $aqClass = new ActiveQuery(Type::class);
+        $aqClass = Type::query();
         $query = $aqClass->one();
 
         $this->assertSame(123, $query->int_col);
@@ -228,7 +228,7 @@ abstract class ActiveRecordTest extends TestCase
         $dog = new Dog();
         $dog->save();
 
-        $animal = (new ActiveQuery(Animal::class))->resultCallback(ModelFactory::create(...));
+        $animal = Animal::query()->resultCallback(ModelFactory::create(...));
 
         $animals = $animal->where(['type' => Dog::class])->one();
         $this->assertEquals('bark', $animals->getDoes());
@@ -626,11 +626,11 @@ abstract class ActiveRecordTest extends TestCase
         $customer->refresh();
         $this->assertFalse($customer->getBoolStatus());
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->where(['bool_status' => true])->all();
         $this->assertCount(2, $customers);
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->where(['bool_status' => false])->all();
         $this->assertCount(2, $customers);
     }
@@ -699,7 +699,7 @@ abstract class ActiveRecordTest extends TestCase
         $this->assertTrue($customer->hasProperty('email'));
         $this->assertFalse($customer->hasProperty('notExist'));
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(1);
         $this->assertTrue($customer->hasProperty('id'));
         $this->assertTrue($customer->hasProperty('email'));
@@ -712,7 +712,7 @@ abstract class ActiveRecordTest extends TestCase
 
         $this->assertFalse($customer->refresh());
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(1);
         $customer->setName('to be refreshed');
 
@@ -748,7 +748,7 @@ abstract class ActiveRecordTest extends TestCase
     {
         $this->reloadFixtureAfterTest();
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->findByPk(2);
 
         $this->assertCount(1, $order->getItemsFor8());
@@ -758,7 +758,7 @@ abstract class ActiveRecordTest extends TestCase
         $this->assertCount(0, $order->getItemsFor8());
         $this->assertCount(2, $order->getOrderItemsWithNullFK());
 
-        $orderItemQuery = new ActiveQuery(OrderItemWithNullFK::class);
+        $orderItemQuery = OrderItemWithNullFK::query();
         $this->assertCount(1, $orderItemQuery->where([
             'order_id' => 2,
             'item_id' => 5,
@@ -771,7 +771,7 @@ abstract class ActiveRecordTest extends TestCase
 
     public function testVirtualRelation(): void
     {
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         /** @var Order $order */
         $order = $orderQuery->findByPk(2);
 
@@ -786,14 +786,14 @@ abstract class ActiveRecordTest extends TestCase
      */
     public function testJoinWithEager(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $eagerCustomers = $customerQuery->joinWith(['items2'])->all();
         $eagerItemsCount = 0;
         foreach ($eagerCustomers as $customer) {
             $eagerItemsCount += is_countable($customer->getItems2()) ? count($customer->getItems2()) : 0;
         }
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $lazyCustomers = $customerQuery->all();
         $lazyItemsCount = 0;
         foreach ($lazyCustomers as $customer) {
@@ -817,7 +817,7 @@ abstract class ActiveRecordTest extends TestCase
         $this->assertSame(1, $customer->primaryKeyValue());
         $this->assertSame(['id' => 1], $customer->primaryKeyValues());
 
-        $orderItemQuery = new ActiveQuery(OrderItem::class);
+        $orderItemQuery = OrderItem::query();
         $orderItem = $orderItemQuery->findByPk([1, 2]);
 
         $this->assertSame(['order_id' => 1, 'item_id' => 2], $orderItem->primaryKeyValues());
@@ -856,7 +856,7 @@ abstract class ActiveRecordTest extends TestCase
         $this->assertSame(1, $customer->primaryKeyOldValue());
         $this->assertSame(['id' => 1], $customer->primaryKeyOldValues());
 
-        $orderItemQuery = new ActiveQuery(OrderItem::class);
+        $orderItemQuery = OrderItem::query();
         $orderItem = $orderItemQuery->findByPk([1, 2]);
         $orderItem->setOrderId(3);
         $orderItem->setItemId(4);
@@ -942,7 +942,7 @@ abstract class ActiveRecordTest extends TestCase
 
     public function testGetDirtyValuesAfterFind(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(1);
 
         $this->assertSame([], $customer->newValues());
@@ -963,7 +963,7 @@ abstract class ActiveRecordTest extends TestCase
 
     public function testRelationWithInstance(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(2);
 
         $orders = $customer->getOrdersUsingInstance();
@@ -1065,7 +1065,7 @@ abstract class ActiveRecordTest extends TestCase
 
     public function testWithFactoryNonInitiated(): void
     {
-        $orderQuery = new ActiveQuery(OrderWithFactory::class);
+        $orderQuery = OrderWithFactory::query();
         $order = $orderQuery->findByPk(2);
 
         $customer = $order->getCustomer();
@@ -1087,7 +1087,7 @@ abstract class ActiveRecordTest extends TestCase
             serialize($profile)
         );
 
-        $profileQuery = new ActiveQuery(Profile::class);
+        $profileQuery = Profile::query();
         $profile = $profileQuery->findByPk(1);
 
         $this->assertEquals(
@@ -1102,7 +1102,7 @@ abstract class ActiveRecordTest extends TestCase
             $this->markTestSkipped('Oracle and MSSQL drivers do not support JSON columns.');
         }
 
-        $promotionQuery = new ActiveQuery(Promotion::class);
+        $promotionQuery = Promotion::query();
         /** @var Promotion[] $promotions */
         $promotions = $promotionQuery->with('itemsViaJson')->all();
 
@@ -1133,7 +1133,7 @@ abstract class ActiveRecordTest extends TestCase
             $this->markTestSkipped('Oracle and MSSQL drivers do not support JSON columns.');
         }
 
-        $itemQuery = new ActiveQuery(Item::class);
+        $itemQuery = Item::query();
         /** @var Item[] $items */
         $items = $itemQuery->all();
 
@@ -1152,7 +1152,7 @@ abstract class ActiveRecordTest extends TestCase
 
     public function testIsChanged(): void
     {
-        $itemQuery = new ActiveQuery(Item::class);
+        $itemQuery = Item::query();
         $item = $itemQuery->findByPk(1);
 
         $this->assertFalse($item->isChanged());

--- a/tests/ArrayableTraitTest.php
+++ b/tests/ArrayableTraitTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests;
 
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Customer;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\CustomerClosureField;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\CustomerForArrayable;

--- a/tests/ArrayableTraitTest.php
+++ b/tests/ArrayableTraitTest.php
@@ -13,7 +13,7 @@ abstract class ArrayableTraitTest extends TestCase
 {
     public function testFields(): void
     {
-        $customerQuery = new ActiveQuery(CustomerForArrayable::class);
+        $customerQuery = CustomerForArrayable::query();
 
         $fields = $customerQuery->findByPk(1)->fields();
 
@@ -35,7 +35,7 @@ abstract class ArrayableTraitTest extends TestCase
 
     public function testToArray(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(1);
 
         $this->assertSame(
@@ -54,7 +54,7 @@ abstract class ArrayableTraitTest extends TestCase
 
     public function testToArrayWithClosure(): void
     {
-        $customerQuery = new ActiveQuery(CustomerClosureField::class);
+        $customerQuery = CustomerClosureField::query();
         $customer = $customerQuery->findByPk(1);
 
         $this->assertSame(
@@ -73,7 +73,7 @@ abstract class ArrayableTraitTest extends TestCase
 
     public function testToArrayForArrayable(): void
     {
-        $customerQuery = new ActiveQuery(CustomerForArrayable::class);
+        $customerQuery = CustomerForArrayable::query();
 
         /** @var CustomerForArrayable $customer */
         $customer = $customerQuery->findByPk(1);

--- a/tests/BatchQueryResultTest.php
+++ b/tests/BatchQueryResultTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests;
 
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Customer;
 use Yiisoft\Db\Query\BatchQueryResultInterface;
 

--- a/tests/BatchQueryResultTest.php
+++ b/tests/BatchQueryResultTest.php
@@ -12,7 +12,7 @@ abstract class BatchQueryResultTest extends TestCase
 {
     public function testQuery(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $query = $customerQuery->orderBy('id');
 
@@ -22,7 +22,7 @@ abstract class BatchQueryResultTest extends TestCase
         $this->assertSame($result->getQuery(), $query);
 
         /** normal query */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $query = $customerQuery->orderBy('id');
 
@@ -65,7 +65,7 @@ abstract class BatchQueryResultTest extends TestCase
         $this->assertCount(0, $allRows);
 
         /** query with index */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $query = $customerQuery->indexBy('name');
 
@@ -81,7 +81,7 @@ abstract class BatchQueryResultTest extends TestCase
         $this->assertEquals('address3', $allRows['user3']->getAddress());
 
         /** each */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $query = $customerQuery->orderBy('id');
 
@@ -96,7 +96,7 @@ abstract class BatchQueryResultTest extends TestCase
         $this->assertEquals('user3', $allRows[2]->getName());
 
         /** each with key */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $query = $customerQuery->orderBy('id')->indexBy('name');
 
@@ -115,7 +115,7 @@ abstract class BatchQueryResultTest extends TestCase
     public function testActiveQuery(): void
     {
         /** batch with eager loading */
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $query = $customerQuery->with('orders')->orderBy('id');
 
@@ -133,7 +133,7 @@ abstract class BatchQueryResultTest extends TestCase
 
     public function testBatchWithIndexBy(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $query = $customerQuery->orderBy('id')->limit(3)->indexBy('id');
 

--- a/tests/Driver/Mssql/ActiveRecordTest.php
+++ b/tests/Driver/Mssql/ActiveRecordTest.php
@@ -56,7 +56,7 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
         $this->assertTrue($record->save());
         $this->assertEquals(1, $record->id);
 
-        $testRecordQuery = new ActiveQuery(TestTriggerAlert::class);
+        $testRecordQuery = TestTriggerAlert::query();
 
         $this->assertEquals('test', $testRecordQuery->findByPk(1)->stringcol);
     }

--- a/tests/Driver/Mssql/ActiveRecordTest.php
+++ b/tests/Driver/Mssql/ActiveRecordTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests\Driver\Mssql;
 
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\TestTrigger;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\TestTriggerAlert;
 use Yiisoft\ActiveRecord\Tests\Support\MssqlHelper;

--- a/tests/Driver/Mssql/MagicActiveRecordTest.php
+++ b/tests/Driver/Mssql/MagicActiveRecordTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests\Driver\Mssql;
 
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord\TestTrigger;
 use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord\TestTriggerAlert;
 use Yiisoft\ActiveRecord\Tests\Support\MssqlHelper;

--- a/tests/Driver/Mssql/MagicActiveRecordTest.php
+++ b/tests/Driver/Mssql/MagicActiveRecordTest.php
@@ -50,7 +50,7 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
         $this->assertTrue($record->save());
         $this->assertEquals(1, $record->id);
 
-        $testRecordQuery = new ActiveQuery(TestTriggerAlert::class);
+        $testRecordQuery = TestTriggerAlert::query();
 
         $this->assertEquals('test', $testRecordQuery->findByPk(1)->stringcol);
     }

--- a/tests/Driver/Mysql/ActiveRecordTest.php
+++ b/tests/Driver/Mysql/ActiveRecordTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests\Driver\Mysql;
 
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Driver\Mysql\Stubs\Type;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Beta;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Customer;

--- a/tests/Driver/Mysql/ActiveRecordTest.php
+++ b/tests/Driver/Mysql/ActiveRecordTest.php
@@ -46,7 +46,7 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
         $arClass->save();
 
         /** @var $model Type */
-        $aqClass = new ActiveQuery(Type::class);
+        $aqClass = Type::query();
         $query = $aqClass->one();
 
         $this->assertSame(123, $query->int_col);
@@ -87,7 +87,7 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
      */
     public function testEagerLoadingUsingStringIdentifiers(): void
     {
-        $betaQuery = new ActiveQuery(Beta::class);
+        $betaQuery = Beta::query();
 
         $betas = $betaQuery->with('alpha')->all();
 

--- a/tests/Driver/Mysql/MagicActiveRecordTest.php
+++ b/tests/Driver/Mysql/MagicActiveRecordTest.php
@@ -41,7 +41,7 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
      */
     public function testEagerLoadingUsingStringIdentifiers(): void
     {
-        $betaQuery = new ActiveQuery(Beta::class);
+        $betaQuery = Beta::query();
 
         $betas = $betaQuery->with('alpha')->all();
 

--- a/tests/Driver/Mysql/MagicActiveRecordTest.php
+++ b/tests/Driver/Mysql/MagicActiveRecordTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests\Driver\Mysql;
 
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord\Beta;
 use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord\Customer;
 use Yiisoft\ActiveRecord\Tests\Support\MysqlHelper;

--- a/tests/Driver/Oracle/ActiveQueryFindTest.php
+++ b/tests/Driver/Oracle/ActiveQueryFindTest.php
@@ -19,17 +19,17 @@ final class ActiveQueryFindTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryF
     public function testFindLimit(): void
     {
         /** one */
-        $customerQuery = new ActiveQuery(CustomerWithRownumid::class);
+        $customerQuery = CustomerWithRownumid::query();
         $customer = $customerQuery->orderBy('id')->one();
         $this->assertEquals('user1', $customer->getName());
 
         /** all */
-        $customerQuery = new ActiveQuery(CustomerWithRownumid::class);
+        $customerQuery = CustomerWithRownumid::query();
         $customers = $customerQuery->all();
         $this->assertCount(3, $customers);
 
         /** limit */
-        $customerQuery = new ActiveQuery(CustomerWithRownumid::class);
+        $customerQuery = CustomerWithRownumid::query();
         $customers = $customerQuery->orderBy('id')->limit(1)->all();
         $this->assertCount(1, $customers);
         $this->assertEquals('user1', $customers[0]->getName());
@@ -51,7 +51,7 @@ final class ActiveQueryFindTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryF
         $this->assertCount(0, $customers);
 
         /** offset */
-        $customerQuery = new ActiveQuery(CustomerWithRownumid::class);
+        $customerQuery = CustomerWithRownumid::query();
         $customer = $customerQuery->orderBy('id')->offset(0)->one();
         $this->assertEquals('user1', $customer->getName());
 

--- a/tests/Driver/Oracle/ActiveQueryFindTest.php
+++ b/tests/Driver/Oracle/ActiveQueryFindTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests\Driver\Oracle;
 
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Driver\Oracle\Stubs\Customer as CustomerWithRownumid;
 use Yiisoft\ActiveRecord\Tests\Support\OracleHelper;
 use Yiisoft\Db\Connection\ConnectionInterface;

--- a/tests/Driver/Oracle/ActiveQueryTest.php
+++ b/tests/Driver/Oracle/ActiveQueryTest.php
@@ -34,7 +34,7 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
     {
         $orders = [];
         /** left join and eager loading */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $query = $orderQuery->joinWith(['customer c']);
 
         if ($aliasMethod === 'explicit') {
@@ -56,7 +56,7 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
         $this->assertTrue($orders[2]->isRelationPopulated('customer'));
 
         /** inner join filtering and eager loading */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $query = $orderQuery->innerJoinWith(['customer c']);
 
         if ($aliasMethod === 'explicit') {
@@ -76,7 +76,7 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
         $this->assertTrue($orders[1]->isRelationPopulated('customer'));
 
         /** inner join filtering without eager loading */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $query = $orderQuery->innerJoinWith(['customer c'], false);
 
         if ($aliasMethod === 'explicit') {
@@ -96,7 +96,7 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
         $this->assertFalse($orders[1]->isRelationPopulated('customer'));
 
         /** join with via-relation */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $query = $orderQuery->innerJoinWith(['books b']);
 
         if ($aliasMethod === 'explicit') {
@@ -122,7 +122,7 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
         $this->assertTrue($orders[1]->isRelationPopulated('books'));
 
         /** joining sub relations */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $query = $orderQuery->innerJoinWith(
             [
                 'items i' => static function ($q) use ($aliasMethod) {
@@ -167,7 +167,7 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
         if ($aliasMethod === 'explicit' || $aliasMethod === 'querysyntax') {
             $relationName = 'books' . ucfirst($aliasMethod);
 
-            $orderQuery = new ActiveQuery(Order::class);
+            $orderQuery = Order::query();
             $orders = $orderQuery->joinWith(["$relationName b"])->orderBy('order.id')->all();
 
             $this->assertCount(3, $orders);
@@ -186,7 +186,7 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
         if ($aliasMethod === 'explicit' || $aliasMethod === 'querysyntax') {
             $relationName = 'books' . ucfirst($aliasMethod) . 'A';
 
-            $orderQuery = new ActiveQuery(Order::class);
+            $orderQuery = Order::query();
             $orders = $orderQuery->joinWith([$relationName])->orderBy('order.id')->all();
 
             $this->assertCount(3, $orders);
@@ -202,7 +202,7 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
         }
 
         /** join with count and query */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $query = $orderQuery->joinWith(['customer c']);
 
         if ($aliasMethod === 'explicit') {
@@ -219,7 +219,7 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
         $this->assertCount(3, $orders);
 
         /** relational query */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->findByPk(1);
 
         $customerQuery = $order->getCustomerQuery()->innerJoinWith(['orders o'], false);
@@ -236,7 +236,7 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
         $this->assertNotNull($customer);
 
         /** join with sub-relation called inside Closure */
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $orders = $orderQuery->joinWith(
             [
                 'items' => static function ($q) use ($aliasMethod) {
@@ -272,7 +272,7 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
          * join with the same table but different aliases alias is defined in the relation definition without eager
          * loading
          */
-        $query = new ActiveQuery(Order::class);
+        $query = Order::query();
         $query
             ->joinWith('bookItems', false)
             ->joinWith('movieItems', false)
@@ -288,7 +288,7 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
         $this->assertFalse($orders[0]->isRelationPopulated('movieItems'));
 
         /** with eager loading */
-        $query = new ActiveQuery(Order::class);
+        $query = Order::query();
         $query->joinWith('bookItems', true)->joinWith('movieItems', true)->where(['{{movies}}.[[name]]' => 'Toy Story']);
         $orders = $query->all();
         $this->assertCount(
@@ -306,7 +306,7 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
          * join with the same table but different aliases alias is defined in the call to joinWith() without eager
          * loading
          */
-        $query = new ActiveQuery(Order::class);
+        $query = Order::query();
         $query
             ->joinWith(
                 [
@@ -333,7 +333,7 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
         $this->assertFalse($orders[0]->isRelationPopulated('itemsIndexed'));
 
         /** with eager loading, only for one relation as it would be overwritten otherwise. */
-        $query = new ActiveQuery(Order::class);
+        $query = Order::query();
         $query
             ->joinWith(
                 [
@@ -358,7 +358,7 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
         $this->assertTrue($orders[0]->isRelationPopulated('itemsIndexed'));
 
         /** with eager loading, and the other relation */
-        $query = new ActiveQuery(Order::class);
+        $query = Order::query();
         $query
             ->joinWith(
                 [

--- a/tests/Driver/Oracle/ActiveRecordTest.php
+++ b/tests/Driver/Oracle/ActiveRecordTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Yiisoft\ActiveRecord\Tests\Driver\Oracle;
 
 use PHPUnit\Framework\Attributes\TestWith;
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Driver\Oracle\Stubs\Customer;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Type;
 use Yiisoft\ActiveRecord\Tests\Support\OracleHelper;

--- a/tests/Driver/Oracle/ActiveRecordTest.php
+++ b/tests/Driver/Oracle/ActiveRecordTest.php
@@ -75,11 +75,11 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
         $customer->refresh();
         $this->assertFalse($customer->getBoolStatus());
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->where(['bool_status' => '1'])->all();
         $this->assertCount(2, $customers);
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->where(['bool_status' => '0'])->all();
         $this->assertCount(2, $customers);
     }

--- a/tests/Driver/Oracle/BatchQueryResultTest.php
+++ b/tests/Driver/Oracle/BatchQueryResultTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests\Driver\Oracle;
 
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Driver\Oracle\Stubs\Customer;
 use Yiisoft\ActiveRecord\Tests\Support\OracleHelper;
 use Yiisoft\Db\Connection\ConnectionInterface;

--- a/tests/Driver/Oracle/BatchQueryResultTest.php
+++ b/tests/Driver/Oracle/BatchQueryResultTest.php
@@ -18,7 +18,7 @@ final class BatchQueryResultTest extends \Yiisoft\ActiveRecord\Tests\BatchQueryR
 
     public function testBatchWithIndexBy(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
 
         $query = $customerQuery->orderBy('id')->limit(3)->indexBy('id');
 

--- a/tests/Driver/Oracle/MagicActiveRecordTest.php
+++ b/tests/Driver/Oracle/MagicActiveRecordTest.php
@@ -67,11 +67,11 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
         $customer->refresh();
         $this->assertFalse($customer->bool_status);
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->where(['bool_status' => '1'])->all();
         $this->assertCount(2, $customers);
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->where(['bool_status' => '0'])->all();
         $this->assertCount(2, $customers);
     }

--- a/tests/Driver/Oracle/MagicActiveRecordTest.php
+++ b/tests/Driver/Oracle/MagicActiveRecordTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests\Driver\Oracle;
 
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Driver\Oracle\Stubs\MagicCustomer as Customer;
 use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord\Type;
 use Yiisoft\ActiveRecord\Tests\Support\OracleHelper;

--- a/tests/Driver/Pgsql/ActiveQueryTest.php
+++ b/tests/Driver/Pgsql/ActiveQueryTest.php
@@ -18,11 +18,11 @@ final class ActiveQueryTest extends \Yiisoft\ActiveRecord\Tests\ActiveQueryTest
 
     public function testBit(): void
     {
-        $bitValueQuery = new ActiveQuery(BitValues::class);
+        $bitValueQuery = BitValues::query();
         $falseBit = $bitValueQuery->findByPk(1);
         $this->assertSame(0, $falseBit->val);
 
-        $bitValueQuery = new ActiveQuery(BitValues::class);
+        $bitValueQuery = BitValues::query();
         $trueBit = $bitValueQuery->findByPk(2);
         $this->assertSame(1, $trueBit->val);
     }

--- a/tests/Driver/Pgsql/ActiveQueryTest.php
+++ b/tests/Driver/Pgsql/ActiveQueryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests\Driver\Pgsql;
 
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\BitValues;
 use Yiisoft\ActiveRecord\Tests\Support\PgsqlHelper;
 use Yiisoft\Db\Connection\ConnectionInterface;

--- a/tests/Driver/Pgsql/ActiveRecordTest.php
+++ b/tests/Driver/Pgsql/ActiveRecordTest.php
@@ -83,7 +83,7 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
         $arClass->save();
 
         /** @var $model Type */
-        $aqClass = new ActiveQuery(Type::class);
+        $aqClass = Type::query();
         $query = $aqClass->one();
 
         $this->assertSame(123, $query->int_col);
@@ -120,7 +120,7 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
      */
     public function testEagerLoadingUsingStringIdentifiers(): void
     {
-        $betaQuery = new ActiveQuery(Beta::class);
+        $betaQuery = Beta::query();
         $betas = $betaQuery->with('alpha')->all();
         $this->assertNotEmpty($betas);
 
@@ -140,7 +140,7 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
     {
         $command = $this->db()->createCommand();
         $command->insertBatch('bool_values', [[true], [false]], ['bool_col'])->execute();
-        $boolARQuery = new ActiveQuery(BoolAR::class);
+        $boolARQuery = BoolAR::query();
 
         $this->assertTrue($boolARQuery->where(['bool_col' => true])->one()->bool_col);
         $this->assertFalse($boolARQuery->setWhere(['bool_col' => false])->one()->bool_col);
@@ -193,7 +193,7 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
         $user->updated_at = time();
         $user->save();
 
-        $userQuery = new ActiveQuery(UserAR::class);
+        $userQuery = UserAR::query();
         $this->assertCount(1, $userQuery->where(['is_deleted' => false])->all());
         $this->assertCount(0, $userQuery->setWhere(['is_deleted' => true])->all());
         $this->assertCount(1, $userQuery->setWhere(['is_deleted' => [true, false]])->all());
@@ -315,7 +315,7 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
 
         $type->save();
 
-        $typeQuery = new ActiveQuery($type::class);
+        $typeQuery = $type::query();
 
         $type = $typeQuery->one();
 
@@ -340,7 +340,7 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
 
     public function testRelationViaArray(): void
     {
-        $promotionQuery = new ActiveQuery(Promotion::class);
+        $promotionQuery = Promotion::query();
         /** @var Promotion[] $promotions */
         $promotions = $promotionQuery->with('itemsViaArray')->all();
 
@@ -367,7 +367,7 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
 
     public function testLazzyRelationViaArray(): void
     {
-        $itemQuery = new ActiveQuery(Item::class);
+        $itemQuery = Item::query();
         /** @var Item[] $items */
         $items = $itemQuery->all();
 

--- a/tests/Driver/Pgsql/ActiveRecordTest.php
+++ b/tests/Driver/Pgsql/ActiveRecordTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests\Driver\Pgsql;
 
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\ArArrayHelper;
 use Yiisoft\ActiveRecord\Tests\Driver\Pgsql\Stubs\Item;
 use Yiisoft\ActiveRecord\Tests\Driver\Pgsql\Stubs\Promotion;

--- a/tests/Driver/Pgsql/MagicActiveRecordTest.php
+++ b/tests/Driver/Pgsql/MagicActiveRecordTest.php
@@ -46,7 +46,7 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
      */
     public function testEagerLoadingUsingStringIdentifiers(): void
     {
-        $betaQuery = new ActiveQuery(Beta::class);
+        $betaQuery = Beta::query();
         $betas = $betaQuery->with('alpha')->all();
         $this->assertNotEmpty($betas);
 
@@ -81,7 +81,7 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
         $customer->refresh();
         $this->assertTrue($customer->bool_status);
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->where(['bool_status' => true])->all();
         $this->assertCount(3, $customers);
 
@@ -93,7 +93,7 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
     {
         $command = $this->db()->createCommand();
         $command->batchInsert('bool_values', ['bool_col'], [[true], [false]])->execute();
-        $boolARQuery = new ActiveQuery(BoolAR::class);
+        $boolARQuery = BoolAR::query();
 
         $this->assertTrue($boolARQuery->where(['bool_col' => true])->one()->bool_col);
         $this->assertFalse($boolARQuery->setWhere(['bool_col' => false])->one()->bool_col);
@@ -146,7 +146,7 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
         $user->updated_at = time();
         $user->save();
 
-        $userQuery = new ActiveQuery(UserAR::class);
+        $userQuery = UserAR::query();
         $this->assertCount(1, $userQuery->where(['is_deleted' => false])->all());
         $this->assertCount(0, $userQuery->setWhere(['is_deleted' => true])->all());
         $this->assertCount(1, $userQuery->setWhere(['is_deleted' => [true, false]])->all());
@@ -266,7 +266,7 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
 
         $type->save();
 
-        $typeQuery = new ActiveQuery($type::class);
+        $typeQuery = $type::query();
 
         $type = $typeQuery->one();
 

--- a/tests/Driver/Pgsql/MagicActiveRecordTest.php
+++ b/tests/Driver/Pgsql/MagicActiveRecordTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests\Driver\Pgsql;
 
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord\ArrayAndJsonTypes;
 use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord\Beta;
 use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord\BoolAR;

--- a/tests/Driver/Sqlite/ActiveRecordTest.php
+++ b/tests/Driver/Sqlite/ActiveRecordTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests\Driver\Sqlite;
 
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Beta;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Customer;
 use Yiisoft\ActiveRecord\Tests\Support\SqliteHelper;

--- a/tests/Driver/Sqlite/ActiveRecordTest.php
+++ b/tests/Driver/Sqlite/ActiveRecordTest.php
@@ -46,7 +46,7 @@ final class ActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\ActiveRecordTes
      */
     public function testEagerLoadingUsingStringIdentifiers(): void
     {
-        $betaQuery = new ActiveQuery(Beta::class);
+        $betaQuery = Beta::query();
 
         $betas = $betaQuery->with('alpha')->all();
 

--- a/tests/Driver/Sqlite/MagicActiveRecordTest.php
+++ b/tests/Driver/Sqlite/MagicActiveRecordTest.php
@@ -40,7 +40,7 @@ final class MagicActiveRecordTest extends \Yiisoft\ActiveRecord\Tests\MagicActiv
      */
     public function testEagerLoadingUsingStringIdentifiers(): void
     {
-        $betaQuery = new ActiveQuery(Beta::class);
+        $betaQuery = Beta::query();
 
         $betas = $betaQuery->with('alpha')->all();
 

--- a/tests/Driver/Sqlite/MagicActiveRecordTest.php
+++ b/tests/Driver/Sqlite/MagicActiveRecordTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests\Driver\Sqlite;
 
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord\Beta;
 use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord\Customer;
 use Yiisoft\ActiveRecord\Tests\Support\SqliteHelper;

--- a/tests/MagicActiveRecordTest.php
+++ b/tests/MagicActiveRecordTest.php
@@ -7,7 +7,6 @@ namespace Yiisoft\ActiveRecord\Tests;
 use DateTimeImmutable;
 use DateTimeZone;
 use DivisionByZeroError;
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord\Alpha;
 use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord\Animal;
 use Yiisoft\ActiveRecord\Tests\Stubs\MagicActiveRecord\Cat;

--- a/tests/MagicActiveRecordTest.php
+++ b/tests/MagicActiveRecordTest.php
@@ -195,7 +195,7 @@ abstract class MagicActiveRecordTest extends TestCase
         $arClass->save();
 
         /** @var $model Type */
-        $aqClass = new ActiveQuery(Type::class);
+        $aqClass = Type::query();
         $query = $aqClass->one();
 
         $this->assertSame(123, $query->int_col);
@@ -221,7 +221,7 @@ abstract class MagicActiveRecordTest extends TestCase
         $dog = new Dog();
         $dog->save();
 
-        $animal = (new ActiveQuery(Animal::class))->resultCallback(ModelFactory::create(...));
+        $animal = Animal::query()->resultCallback(ModelFactory::create(...));
 
         $animals = $animal->where(['type' => Dog::class])->one();
         $this->assertEquals('bark', $animals->getDoes());
@@ -444,11 +444,11 @@ abstract class MagicActiveRecordTest extends TestCase
         $customer->refresh();
         $this->assertFalse($customer->bool_status);
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->where(['bool_status' => true])->all();
         $this->assertCount(2, $customers);
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customers = $customerQuery->where(['bool_status' => false])->all();
         $this->assertCount(2, $customers);
     }
@@ -515,7 +515,7 @@ abstract class MagicActiveRecordTest extends TestCase
         $this->assertTrue($customer->hasProperty('email'));
         $this->assertFalse($customer->hasProperty('notExist'));
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(1);
         $this->assertTrue($customer->hasProperty('id'));
         $this->assertTrue($customer->hasProperty('email'));
@@ -537,7 +537,7 @@ abstract class MagicActiveRecordTest extends TestCase
 
         $this->assertFalse($customer->refresh());
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(1);
         $customer->name = 'to be refreshed';
 
@@ -573,7 +573,7 @@ abstract class MagicActiveRecordTest extends TestCase
     {
         $this->reloadFixtureAfterTest();
 
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         $order = $orderQuery->findByPk(2);
 
         $this->assertCount(1, $order->itemsFor8);
@@ -583,7 +583,7 @@ abstract class MagicActiveRecordTest extends TestCase
         $this->assertCount(0, $order->itemsFor8);
         $this->assertCount(2, $order->orderItemsWithNullFK);
 
-        $orderItemQuery = new ActiveQuery(OrderItemWithNullFK::class);
+        $orderItemQuery = OrderItemWithNullFK::query();
         $this->assertCount(1, $orderItemQuery->where([
             'order_id' => 2,
             'item_id' => 5,
@@ -596,7 +596,7 @@ abstract class MagicActiveRecordTest extends TestCase
 
     public function testVirtualRelation(): void
     {
-        $orderQuery = new ActiveQuery(Order::class);
+        $orderQuery = Order::query();
         /** @var Order $order */
         $order = $orderQuery->findByPk(2);
 
@@ -611,14 +611,14 @@ abstract class MagicActiveRecordTest extends TestCase
      */
     public function testJoinWithEager(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $eagerCustomers = $customerQuery->joinWith(['items2'])->all();
         $eagerItemsCount = 0;
         foreach ($eagerCustomers as $customer) {
             $eagerItemsCount += is_countable($customer->items2) ? count($customer->items2) : 0;
         }
 
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $lazyCustomers = $customerQuery->all();
         $lazyItemsCount = 0;
         foreach ($lazyCustomers as $customer) {
@@ -642,7 +642,7 @@ abstract class MagicActiveRecordTest extends TestCase
         $this->assertSame(1, $customer->primaryKeyValue());
         $this->assertSame(['id' => 1], $customer->primaryKeyValues());
 
-        $orderItemQuery = new ActiveQuery(OrderItem::class);
+        $orderItemQuery = OrderItem::query();
         $orderItem = $orderItemQuery->findByPk([1, 2]);
 
         $this->assertSame(['order_id' => 1, 'item_id' => 2], $orderItem->primaryKeyValues());
@@ -681,7 +681,7 @@ abstract class MagicActiveRecordTest extends TestCase
         $this->assertSame(1, $customer->primaryKeyOldValue());
         $this->assertSame(['id' => 1], $customer->primaryKeyOldValues());
 
-        $orderItemQuery = new ActiveQuery(OrderItem::class);
+        $orderItemQuery = OrderItem::query();
         $orderItem = $orderItemQuery->findByPk([1, 2]);
         $orderItem->order_id = 3;
         $orderItem->item_id = 4;
@@ -745,7 +745,7 @@ abstract class MagicActiveRecordTest extends TestCase
 
     public function testGetDirtyValuesAfterFind(): void
     {
-        $customerQuery = new ActiveQuery(Customer::class);
+        $customerQuery = Customer::query();
         $customer = $customerQuery->findByPk(1);
 
         $this->assertSame([], $customer->newValues());
@@ -772,7 +772,7 @@ abstract class MagicActiveRecordTest extends TestCase
             'address' => null,
         ], $customer->newValues());
 
-        $customerQuery = new ActiveQuery(CustomerWithProperties::class);
+        $customerQuery = CustomerWithProperties::query();
         $customer = $customerQuery->findByPk(1);
 
         $this->assertSame([], $customer->newValues());
@@ -833,7 +833,7 @@ abstract class MagicActiveRecordTest extends TestCase
 
     public function testIsChanged(): void
     {
-        $itemQuery = new ActiveQuery(Item::class);
+        $itemQuery = Item::query();
         $item = $itemQuery->findByPk(1);
 
         $this->assertFalse($item->isChanged());

--- a/tests/RepositoryTraitTest.php
+++ b/tests/RepositoryTraitTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\ActiveRecord\Tests;
 
-use Yiisoft\ActiveRecord\ActiveQuery;
 use Yiisoft\ActiveRecord\NotFoundException;
 use Yiisoft\ActiveRecord\Tests\Stubs\ActiveRecord\Customer;
 

--- a/tests/RepositoryTraitTest.php
+++ b/tests/RepositoryTraitTest.php
@@ -12,7 +12,7 @@ abstract class RepositoryTraitTest extends TestCase
 {
     public function testFind(): void
     {
-        $customerQuery = new ActiveQuery(new Customer());
+        $customerQuery = Customer::query();
 
         $this->assertEquals(
             $customerQuery->setWhere(['id' => 1]),
@@ -22,7 +22,7 @@ abstract class RepositoryTraitTest extends TestCase
 
     public function testFindOne(): void
     {
-        $customerQuery = new ActiveQuery(new Customer());
+        $customerQuery = Customer::query();
 
         $this->assertEquals(
             $customerQuery->where(['id' => 1])->one(),
@@ -48,7 +48,7 @@ abstract class RepositoryTraitTest extends TestCase
 
     public function testFindOneOrFail(): void
     {
-        $customerQuery = new ActiveQuery(new Customer());
+        $customerQuery = Customer::query();
 
         $this->assertEquals(
             $customerQuery->where(['id' => 1])->one(),
@@ -63,7 +63,7 @@ abstract class RepositoryTraitTest extends TestCase
 
     public function testFindAll(): void
     {
-        $customerQuery = new ActiveQuery(new Customer());
+        $customerQuery = Customer::query();
 
         $this->assertEquals(
             $customerQuery->all(),
@@ -81,7 +81,7 @@ abstract class RepositoryTraitTest extends TestCase
 
     public function testFindAllOrFail(): void
     {
-        $customerQuery = new ActiveQuery(new Customer());
+        $customerQuery = Customer::query();
 
         $this->assertEquals(
             $customerQuery->where(['id' => [1, 2, 3]])->all(),
@@ -96,7 +96,7 @@ abstract class RepositoryTraitTest extends TestCase
 
     public function testFindByPk(): void
     {
-        $customerQuery = new ActiveQuery(new Customer());
+        $customerQuery = Customer::query();
 
         $this->assertEquals(
             $customerQuery->where(['id' => 1])->one(),
@@ -109,7 +109,7 @@ abstract class RepositoryTraitTest extends TestCase
 
     public function testFindByPkOrFail(): void
     {
-        $customerQuery = new ActiveQuery(new Customer());
+        $customerQuery = Customer::query();
 
         $this->assertEquals(
             $customerQuery->where(['id' => 1])->one(),
@@ -124,7 +124,7 @@ abstract class RepositoryTraitTest extends TestCase
 
     public function testFindBySql(): void
     {
-        $customerQuery = new ActiveQuery(new Customer());
+        $customerQuery = Customer::query();
 
         $this->assertEquals(
             $customerQuery->sql('SELECT * FROM {{customer}}'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | 