### PR TITLE
Rename `ActiveQueryInterface::getMultiple()` to `isMultiple()`

### DIFF
--- a/src/AbstractActiveRecord.php
+++ b/src/AbstractActiveRecord.php
@@ -491,7 +491,7 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
         }
 
         // Update lazily loaded related objects.
-        if (!$relation->getMultiple()) {
+        if (!$relation->isMultiple()) {
             $this->related[$relationName] = $linkModel;
         } elseif (isset($this->related[$relationName])) {
             /** @psalm-var ActiveRecordInterface[] $this->related[$relationName] */
@@ -881,7 +881,7 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
             }
         }
 
-        if (!$relation->getMultiple()) {
+        if (!$relation->isMultiple()) {
             unset($this->related[$relationName]);
         } elseif (isset($this->related[$relationName]) && is_array($this->related[$relationName])) {
             /** @psalm-var array<array-key, ActiveRecordInterface> $related */

--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -184,7 +184,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
             } elseif (is_array($this->via)) {
                 [$viaName, $viaQuery, $viaCallableUsed] = $this->via;
 
-                if ($viaQuery->getMultiple()) {
+                if ($viaQuery->isMultiple()) {
                     if ($viaCallableUsed) {
                         $viaModels = $viaQuery->all();
                     } elseif ($this->primaryModel->isRelationPopulated($viaName)) {

--- a/src/ActiveQueryInterface.php
+++ b/src/ActiveQueryInterface.php
@@ -448,12 +448,11 @@ interface ActiveQueryInterface extends QueryInterface
      *
      * This property is only used in relational context.
      *
-     * If `true`, this relation will populate all query results into active record instances using
-     * {@see all()}.
+     * If `true`, this relation will populate all query results into active record instances using {@see all()}.
      *
      * If `false`, only the first row of the results will be retrieved using {@see one()}.
      */
-    public function getMultiple(): bool;
+    public function isMultiple(): bool;
 
     /**
      * @inheritdoc

--- a/src/ActiveRelationTrait.php
+++ b/src/ActiveRelationTrait.php
@@ -206,7 +206,7 @@ trait ActiveRelationTrait
 
         if ($relatedModel instanceof ActiveRecordInterface) {
             $inverseRelation = $relatedModel->relationQuery($this->inverseOf);
-            $primaryModel = $inverseRelation->getMultiple() ? [$this->primaryModel] : $this->primaryModel;
+            $primaryModel = $inverseRelation->isMultiple() ? [$this->primaryModel] : $this->primaryModel;
 
             /** @var ActiveRecordInterface $relatedModel */
             foreach ($result as $relatedModel) {
@@ -214,7 +214,7 @@ trait ActiveRelationTrait
             }
         } else {
             $inverseRelation = $this->getModel()->relationQuery($this->inverseOf);
-            $primaryModel = $inverseRelation->getMultiple() ? [$this->primaryModel] : $this->primaryModel;
+            $primaryModel = $inverseRelation->isMultiple() ? [$this->primaryModel] : $this->primaryModel;
 
             /** @var array $relatedModel */
             foreach ($result as &$relatedModel) {
@@ -334,7 +334,7 @@ trait ActiveRelationTrait
         $indexBy = $relation->getIndexBy();
         $buckets = $relation->buildBuckets($primaryModels);
 
-        if ($indexBy !== null && $relation->getMultiple()) {
+        if ($indexBy !== null && $relation->isMultiple()) {
             $buckets = $this->indexBuckets($buckets, $indexBy);
         }
 
@@ -505,7 +505,7 @@ trait ActiveRelationTrait
         };
     }
 
-    public function getMultiple(): bool
+    public function isMultiple(): bool
     {
         return $this->multiple;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️

