### PR TITLE
Use constructors

### DIFF
--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -163,7 +163,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     ) {
         $this->model = $modelClass instanceof ActiveRecordInterface
             ? $modelClass
-            : (new ReflectionClass($modelClass))->newInstanceWithoutConstructor();
+            : (new ReflectionClass($modelClass))->newInstance();
 
         parent::__construct($this->model->db());
     }

--- a/src/Trait/EventsTrait.php
+++ b/src/Trait/EventsTrait.php
@@ -86,7 +86,7 @@ trait EventsTrait
     {
         $model = $modelClass instanceof ActiveRecordInterface
             ? $modelClass
-            : (new ReflectionClass($modelClass ?? static::class))->newInstance();
+            : (new ReflectionClass($modelClass ?? static::class))->newInstanceWithoutConstructor();
 
         $eventDispatcher = EventDispatcherProvider::get($model::class);
         $eventDispatcher->dispatch($event = new BeforeCreateQuery($model));

--- a/src/Trait/EventsTrait.php
+++ b/src/Trait/EventsTrait.php
@@ -86,7 +86,7 @@ trait EventsTrait
     {
         $model = $modelClass instanceof ActiveRecordInterface
             ? $modelClass
-            : (new ReflectionClass($modelClass ?? static::class))->newInstanceWithoutConstructor();
+            : (new ReflectionClass($modelClass ?? static::class))->newInstance();
 
         $eventDispatcher = EventDispatcherProvider::get($model::class);
         $eventDispatcher->dispatch($event = new BeforeCreateQuery($model));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

My code broke with #538, due to constructors suddenly being disabled. This PR leaves the changes from that PR, but reintroduces constructors.
My dev environment does not have all the elements to run tests. This PR serves to trigger the GH actions.