### PR TITLE
Remove check for empty name in `markPropertyChanged()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bug #561: Fix `ActiveRecordInterface::upsert()` with `$updateProperties = false` (@Tigrov)
 - Bug #550: Relation query should be created by related class, not primary model class (@batyrmastyr)
 - Enh #571: Optimize performance of `ActiveRecord::get()` method (@Tigrov)
+- Enh #575: Remove check for empty string in `AbstractActiveRecord::markPropertyChanged()` method (@Tigrov)
 
 ## 1.0.2 March 11, 2026
 

--- a/src/AbstractActiveRecord.php
+++ b/src/AbstractActiveRecord.php
@@ -391,7 +391,7 @@ abstract class AbstractActiveRecord implements ActiveRecordInterface
 
     public function markPropertyChanged(string $name): void
     {
-        if ($this->oldValues !== null && $name !== '') {
+        if ($this->oldValues !== null) {
             unset($this->oldValues[$name]);
         }
     }

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -1634,6 +1634,16 @@ abstract class ActiveRecordTest extends TestCase
         $this->assertSame($expectedAffectedRows, $affectedRows);
     }
 
+    public function testMarkPropertyChangedWithEmptyName()
+    {
+        $model = new NullValues();
+        $model->assignOldValues(['' => 'empty name', 'name' => 'Vasya']);
+
+        $model->markPropertyChanged('');
+
+        $this->assertSame(['name' => 'Vasya'], $model->oldValues());
+    }
+
     public function testMarkAsNew(): void
     {
         $this->reloadFixtureAfterTest();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #551
